### PR TITLE
FT-591 fixup valgrind block_allocator_test fails

### DIFF
--- a/ft/serialize/block_allocator.cc
+++ b/ft/serialize/block_allocator.cc
@@ -177,6 +177,7 @@ void block_allocator::grow_blocks_array_by(uint64_t n_to_add) {
         }
         _blocks_array_size = new_size;
         XREALLOC_N(_blocks_array_size, _blocks_array);
+        memset(_blocks_array + _n_blocks, 0, sizeof(*_blocks_array) * (_blocks_array_size - _n_blocks));
     }
 }
 


### PR DESCRIPTION
If forward is false, the first bp point to blocks_array[used - 1], so the bp[1] is uninitialised