### PR TITLE
posix_memalign() is allowed to return NULL if the size is zero.  toku_xm...

### DIFF
--- a/portability/memory.cc
+++ b/portability/memory.cc
@@ -373,7 +373,7 @@ void* toku_xmalloc_aligned(size_t alignment, size_t size)
         status.max_requested_size = size;
     }
     void *p = t_xmalloc_aligned ? t_xmalloc_aligned(alignment, size) : os_malloc_aligned(alignment,size);
-    if (p == NULL) {
+    if (p == NULL && size != 0) {
         status.last_failed_size = size;
         resource_assert(p);
     }


### PR DESCRIPTION
posix_memalign() is allowed to return NULL if the size is zero.  toku_xmalloc_aligned() has an overactive assertion that complains in this situation. The assertion triggers when running ft-test with an implementation that returns NULL on zero-sized values.  This patch allows ft-test run to completion with such an implementation of posix_memalign().
