### PR TITLE
FT-675 : Removed unnecessary assertion on setlocale() success in ctes…

### DIFF
--- a/src/tests/threaded_stress_test_helpers.h
+++ b/src/tests/threaded_stress_test_helpers.h
@@ -2890,7 +2890,7 @@ open_and_stress_tables(struct cli_args *args, bool fill_with_zeroes, int (*cmp)(
         return;
     }
 
-    { char *loc = setlocale(LC_NUMERIC, "en_US.UTF-8"); assert(loc); }
+    setlocale(LC_NUMERIC, "en_US.UTF-8");
     DB_ENV* env = nullptr;
     DB* dbs[args->num_DBs];
     memset(dbs, 0, sizeof(dbs));


### PR DESCRIPTION
…t suite

that causes Percona Jenkins failures. According to Leif, setlocale was only
being called so that commas were added to big numbers in printf("%'d").

Jenkins : http://jenkins.percona.com/view/TokuDB/job/ft-index-param/9/