### PR TITLE
FT-669 : Refactor status to it's own file/sybsystem within ft-index

### DIFF
--- a/ft/CMakeLists.txt
+++ b/ft/CMakeLists.txt
@@ -36,6 +36,7 @@ set(FT_SOURCES
   ft-flusher
   ft-hot-flusher
   ft-ops
+  ft-status
   ft-test-helpers
   ft-verify
   loader/callbacks

--- a/ft/cachetable/cachetable.h
+++ b/ft/cachetable/cachetable.h
@@ -97,6 +97,7 @@ PATENT RIGHTS GRANT:
 #include "ft/logger/logger.h"
 #include "ft/serialize/block_table.h"
 #include "ft/txn/txn.h"
+#include "ft/ft-status.h"
 #include "util/minicron.h"
 
 // Maintain a cache mapping from cachekeys to values (void*)
@@ -589,34 +590,6 @@ void toku_cachetable_maybe_flush_some(CACHETABLE ct);
 
 // for stat64
 uint64_t toku_cachefile_size(CACHEFILE cf);
-
-typedef enum {
-    CT_MISS = 0,
-    CT_MISSTIME,               // how many usec spent waiting for disk read because of cache miss
-    CT_PREFETCHES,             // how many times has a block been prefetched into the cachetable?
-    CT_SIZE_CURRENT,           // the sum of the sizes of the nodes represented in the cachetable
-    CT_SIZE_LIMIT,             // the limit to the sum of the node sizes
-    CT_SIZE_WRITING,           // the sum of the sizes of the nodes being written
-    CT_SIZE_NONLEAF,           // number of bytes in cachetable belonging to nonleaf nodes
-    CT_SIZE_LEAF,              // number of bytes in cachetable belonging to leaf nodes
-    CT_SIZE_ROLLBACK,          // number of bytes in cachetable belonging to rollback nodes
-    CT_SIZE_CACHEPRESSURE,     // number of bytes causing cache pressure (sum of buffers and workdone counters)
-    CT_SIZE_CLONED,            // number of bytes of cloned data in the system
-    CT_EVICTIONS,
-    CT_CLEANER_EXECUTIONS,     // number of times the cleaner thread's loop has executed
-    CT_CLEANER_PERIOD,
-    CT_CLEANER_ITERATIONS,     // number of times the cleaner thread runs the cleaner per period
-    CT_WAIT_PRESSURE_COUNT,
-    CT_WAIT_PRESSURE_TIME,
-    CT_LONG_WAIT_PRESSURE_COUNT,
-    CT_LONG_WAIT_PRESSURE_TIME,
-    CT_STATUS_NUM_ROWS
-} ct_status_entry;
-
-typedef struct {
-    bool initialized;
-    TOKU_ENGINE_STATUS_ROW_S status[CT_STATUS_NUM_ROWS];
-} CACHETABLE_STATUS_S, *CACHETABLE_STATUS;
 
 void toku_cachetable_get_status(CACHETABLE ct, CACHETABLE_STATUS s);
 

--- a/ft/cachetable/checkpoint.h
+++ b/ft/cachetable/checkpoint.h
@@ -171,30 +171,4 @@ int toku_checkpoint(CHECKPOINTER cp, struct tokulogger *logger,
  * Some status information may be incorrect because no locks are taken to collect status.
  * (If checkpoint is in progress, it may overwrite status info while it is being read.)
  *****/
-typedef enum {
-    CP_PERIOD,
-    CP_FOOTPRINT,
-    CP_TIME_LAST_CHECKPOINT_BEGIN,
-    CP_TIME_LAST_CHECKPOINT_BEGIN_COMPLETE,
-    CP_TIME_LAST_CHECKPOINT_END,
-    CP_TIME_CHECKPOINT_DURATION,
-    CP_TIME_CHECKPOINT_DURATION_LAST,
-    CP_LAST_LSN,
-    CP_CHECKPOINT_COUNT,
-    CP_CHECKPOINT_COUNT_FAIL,
-    CP_WAITERS_NOW,          // how many threads are currently waiting for the checkpoint_safe lock to perform a checkpoint
-    CP_WAITERS_MAX,          // max threads ever simultaneously waiting for the checkpoint_safe lock to perform a checkpoint
-    CP_CLIENT_WAIT_ON_MO,    // how many times a client thread waited to take the multi_operation lock, not for checkpoint
-    CP_CLIENT_WAIT_ON_CS,    // how many times a client thread waited for the checkpoint_safe lock, not for checkpoint
-    CP_BEGIN_TIME,
-    CP_LONG_BEGIN_TIME,
-    CP_LONG_BEGIN_COUNT,
-    CP_STATUS_NUM_ROWS       // number of rows in this status array.  must be last.
-} cp_status_entry;
-
-typedef struct {
-    bool initialized;
-    TOKU_ENGINE_STATUS_ROW_S status[CP_STATUS_NUM_ROWS];
-} CHECKPOINT_STATUS_S, *CHECKPOINT_STATUS;
-
 void toku_checkpoint_get_status(CACHETABLE ct, CHECKPOINT_STATUS stat);

--- a/ft/ft-flusher.h
+++ b/ft/ft-flusher.h
@@ -93,46 +93,6 @@ PATENT RIGHTS GRANT:
 
 #include "ft/ft-internal.h"
 
-typedef enum {
-    FT_FLUSHER_CLEANER_TOTAL_NODES = 0,     // total number of nodes whose buffers are potentially flushed by cleaner thread
-    FT_FLUSHER_CLEANER_H1_NODES,            // number of nodes of height one whose message buffers are flushed by cleaner thread
-    FT_FLUSHER_CLEANER_HGT1_NODES,          // number of nodes of height > 1 whose message buffers are flushed by cleaner thread
-    FT_FLUSHER_CLEANER_EMPTY_NODES,         // number of nodes that are selected by cleaner, but whose buffers are empty
-    FT_FLUSHER_CLEANER_NODES_DIRTIED,       // number of nodes that are made dirty by the cleaner thread
-    FT_FLUSHER_CLEANER_MAX_BUFFER_SIZE,     // max number of bytes in message buffer flushed by cleaner thread
-    FT_FLUSHER_CLEANER_MIN_BUFFER_SIZE,
-    FT_FLUSHER_CLEANER_TOTAL_BUFFER_SIZE,
-    FT_FLUSHER_CLEANER_MAX_BUFFER_WORKDONE, // max workdone value of any message buffer flushed by cleaner thread
-    FT_FLUSHER_CLEANER_MIN_BUFFER_WORKDONE,
-    FT_FLUSHER_CLEANER_TOTAL_BUFFER_WORKDONE,
-    FT_FLUSHER_CLEANER_NUM_LEAF_MERGES_STARTED,     // number of times cleaner thread tries to merge a leaf
-    FT_FLUSHER_CLEANER_NUM_LEAF_MERGES_RUNNING,     // number of cleaner thread leaf merges in progress
-    FT_FLUSHER_CLEANER_NUM_LEAF_MERGES_COMPLETED,   // number of times cleaner thread successfully merges a leaf
-    FT_FLUSHER_CLEANER_NUM_DIRTIED_FOR_LEAF_MERGE,  // nodes dirtied by the "flush from root" process to merge a leaf node
-    FT_FLUSHER_FLUSH_TOTAL,                 // total number of flushes done by flusher threads or cleaner threads
-    FT_FLUSHER_FLUSH_IN_MEMORY,             // number of in memory flushes
-    FT_FLUSHER_FLUSH_NEEDED_IO,             // number of flushes that had to read a child (or part) off disk
-    FT_FLUSHER_FLUSH_CASCADES,              // number of flushes that triggered another flush in the child
-    FT_FLUSHER_FLUSH_CASCADES_1,            // number of flushes that triggered 1 cascading flush
-    FT_FLUSHER_FLUSH_CASCADES_2,            // number of flushes that triggered 2 cascading flushes
-    FT_FLUSHER_FLUSH_CASCADES_3,            // number of flushes that triggered 3 cascading flushes
-    FT_FLUSHER_FLUSH_CASCADES_4,            // number of flushes that triggered 4 cascading flushes
-    FT_FLUSHER_FLUSH_CASCADES_5,            // number of flushes that triggered 5 cascading flushes
-    FT_FLUSHER_FLUSH_CASCADES_GT_5,         // number of flushes that triggered more than 5 cascading flushes
-    FT_FLUSHER_SPLIT_LEAF,                  // number of leaf nodes split
-    FT_FLUSHER_SPLIT_NONLEAF,               // number of nonleaf nodes split
-    FT_FLUSHER_MERGE_LEAF,                  // number of times leaf nodes are merged
-    FT_FLUSHER_MERGE_NONLEAF,               // number of times nonleaf nodes are merged
-    FT_FLUSHER_BALANCE_LEAF,                // number of times a leaf node is balanced
-    FT_FLUSHER_STATUS_NUM_ROWS
-} ft_flusher_status_entry;
-
-typedef struct {
-    bool initialized;
-    TOKU_ENGINE_STATUS_ROW_S status[FT_FLUSHER_STATUS_NUM_ROWS];
-} FT_FLUSHER_STATUS_S, *FT_FLUSHER_STATUS;
-
-void toku_ft_flusher_status_init(void) __attribute__((__constructor__));
 void toku_ft_flusher_get_status(FT_FLUSHER_STATUS);
 
 /**
@@ -225,21 +185,6 @@ ft_nonleaf_split(
  * HOT optimize, should perhaps be factored out to its own header file  *
  ************************************************************************
  */
-
-typedef enum {
-    FT_HOT_NUM_STARTED = 0,      // number of HOT operations that have begun
-    FT_HOT_NUM_COMPLETED,        // number of HOT operations that have successfully completed
-    FT_HOT_NUM_ABORTED,          // number of HOT operations that have been aborted
-    FT_HOT_MAX_ROOT_FLUSH_COUNT, // max number of flushes from root ever required to optimize a tree
-    FT_HOT_STATUS_NUM_ROWS
-} ft_hot_status_entry;
-
-typedef struct {
-    bool initialized;
-    TOKU_ENGINE_STATUS_ROW_S status[FT_HOT_STATUS_NUM_ROWS];
-} FT_HOT_STATUS_S, *FT_HOT_STATUS;
-
-void toku_ft_hot_status_init(void) __attribute__((__constructor__));
 void toku_ft_hot_get_status(FT_HOT_STATUS);
 
 /**

--- a/ft/ft-hot-flusher.cc
+++ b/ft/ft-hot-flusher.cc
@@ -118,29 +118,9 @@ struct hot_flusher_extra {
     bool rightmost_leaf_seen;
 };
 
-static FT_HOT_STATUS_S hot_status;
-
-#define STATUS_INIT(k,c,t,l,inc) TOKUFT_STATUS_INIT(hot_status, k, c, t, "hot: " l, inc)
-
-#define STATUS_VALUE(x) hot_status.status[x].value.num
-
-void
-toku_ft_hot_status_init(void)
-{
-    STATUS_INIT(FT_HOT_NUM_STARTED,          nullptr, UINT64, "operations ever started", TOKU_ENGINE_STATUS);
-    STATUS_INIT(FT_HOT_NUM_COMPLETED,        nullptr, UINT64, "operations successfully completed", TOKU_ENGINE_STATUS);
-    STATUS_INIT(FT_HOT_NUM_ABORTED,          nullptr, UINT64, "operations aborted", TOKU_ENGINE_STATUS);
-    STATUS_INIT(FT_HOT_MAX_ROOT_FLUSH_COUNT, nullptr, UINT64, "max number of flushes from root ever required to optimize a tree", TOKU_ENGINE_STATUS);
-
-    hot_status.initialized = true;
-}
-#undef STATUS_INIT
-
 void
 toku_ft_hot_get_status(FT_HOT_STATUS s) {
-    if (!hot_status.initialized) {
-        toku_ft_hot_status_init();
-    }
+    hot_status.init();
     *s = hot_status;
 }
 
@@ -312,7 +292,7 @@ toku_ft_hot_optimize(FT_HANDLE ft_handle, DBT* left, DBT* right,
     uint64_t loop_count = 0;
     MSN msn_at_start_of_hot = ZERO_MSN;  // capture msn from root at
                                          // start of HOT operation
-    (void) toku_sync_fetch_and_add(&STATUS_VALUE(FT_HOT_NUM_STARTED), 1);
+    (void) toku_sync_fetch_and_add(&HOT_STATUS_VAL(FT_HOT_NUM_STARTED), 1);
 
     toku_ft_note_hot_begin(ft_handle);
 
@@ -348,8 +328,8 @@ toku_ft_hot_optimize(FT_HANDLE ft_handle, DBT* left, DBT* right,
 
         loop_count++;
 
-        if (loop_count > STATUS_VALUE(FT_HOT_MAX_ROOT_FLUSH_COUNT)) {
-            STATUS_VALUE(FT_HOT_MAX_ROOT_FLUSH_COUNT) = loop_count;
+        if (loop_count > HOT_STATUS_VAL(FT_HOT_MAX_ROOT_FLUSH_COUNT)) {
+            HOT_STATUS_VAL(FT_HOT_MAX_ROOT_FLUSH_COUNT) = loop_count;
         }
 
         // Initialize the maximum current key.  We need to do this for
@@ -417,9 +397,9 @@ toku_ft_hot_optimize(FT_HANDLE ft_handle, DBT* left, DBT* right,
         }
 
         if (success) {
-            (void) toku_sync_fetch_and_add(&STATUS_VALUE(FT_HOT_NUM_COMPLETED), 1);
+            (void) toku_sync_fetch_and_add(&HOT_STATUS_VAL(FT_HOT_NUM_COMPLETED), 1);
         } else {
-            (void) toku_sync_fetch_and_add(&STATUS_VALUE(FT_HOT_NUM_ABORTED), 1);
+            (void) toku_sync_fetch_and_add(&HOT_STATUS_VAL(FT_HOT_NUM_ABORTED), 1);
         }
     }
     return r;
@@ -432,6 +412,3 @@ toku_hot_helgrind_ignore(void) {
     // incremented only while lock is held, but read by engine status asynchronously.
     TOKU_VALGRIND_HG_DISABLE_CHECKING(&hot_status, sizeof hot_status);
 }
-
-
-#undef STATUS_VALUE

--- a/ft/ft-ops.cc
+++ b/ft/ft-ops.cc
@@ -235,205 +235,44 @@ basement nodes, bulk fetch,  and partial fetch:
 /* Status is intended for display to humans to help understand system behavior.
  * It does not need to be perfectly thread-safe.
  */
-static FT_STATUS_S ft_status;
-
-#define STATUS_INIT(k,c,t,l,inc) TOKUFT_STATUS_INIT(ft_status, k, c, t, "ft: " l, inc)
 
 static toku_mutex_t ft_open_close_lock;
 
-static void
-status_init(void)
-{
-    // Note, this function initializes the keyname, type, and legend fields.
-    // Value fields are initialized to zero by compiler.
-    STATUS_INIT(FT_UPDATES,                                DICTIONARY_UPDATES, PARCOUNT, "dictionary updates", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_UPDATES_BROADCAST,                      DICTIONARY_BROADCAST_UPDATES, PARCOUNT, "dictionary broadcast updates", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_DESCRIPTOR_SET,                         DESCRIPTOR_SET, PARCOUNT, "descriptor set", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_MSN_DISCARDS,                           MESSAGES_IGNORED_BY_LEAF_DUE_TO_MSN, PARCOUNT, "messages ignored by leaf due to msn", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_TOTAL_RETRIES,                          nullptr, PARCOUNT, "total search retries due to TRY_AGAIN", TOKU_ENGINE_STATUS);
-    STATUS_INIT(FT_SEARCH_TRIES_GT_HEIGHT,                 nullptr, PARCOUNT, "searches requiring more tries than the height of the tree", TOKU_ENGINE_STATUS);
-    STATUS_INIT(FT_SEARCH_TRIES_GT_HEIGHTPLUS3,            nullptr, PARCOUNT, "searches requiring more tries than the height of the tree plus three", TOKU_ENGINE_STATUS);
-    STATUS_INIT(FT_CREATE_LEAF,                            LEAF_NODES_CREATED, PARCOUNT, "leaf nodes created", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_CREATE_NONLEAF,                         NONLEAF_NODES_CREATED, PARCOUNT, "nonleaf nodes created", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_DESTROY_LEAF,                           LEAF_NODES_DESTROYED, PARCOUNT, "leaf nodes destroyed", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_DESTROY_NONLEAF,                        NONLEAF_NODES_DESTROYED, PARCOUNT, "nonleaf nodes destroyed", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_MSG_BYTES_IN,                           MESSAGES_INJECTED_AT_ROOT_BYTES, PARCOUNT, "bytes of messages injected at root (all trees)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_MSG_BYTES_OUT,                          MESSAGES_FLUSHED_FROM_H1_TO_LEAVES_BYTES, PARCOUNT, "bytes of messages flushed from h1 nodes to leaves", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_MSG_BYTES_CURR,                         MESSAGES_IN_TREES_ESTIMATE_BYTES, PARCOUNT, "bytes of messages currently in trees (estimate)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_MSG_NUM,                                MESSAGES_INJECTED_AT_ROOT, PARCOUNT, "messages injected at root", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_MSG_NUM_BROADCAST,                      BROADCASE_MESSAGES_INJECTED_AT_ROOT, PARCOUNT, "broadcast messages injected at root", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-
-    STATUS_INIT(FT_NUM_BASEMENTS_DECOMPRESSED_NORMAL,      BASEMENTS_DECOMPRESSED_TARGET_QUERY, PARCOUNT, "basements decompressed as a target of a query", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_NUM_BASEMENTS_DECOMPRESSED_AGGRESSIVE,  BASEMENTS_DECOMPRESSED_PRELOCKED_RANGE, PARCOUNT, "basements decompressed for prelocked range", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_NUM_BASEMENTS_DECOMPRESSED_PREFETCH,    BASEMENTS_DECOMPRESSED_PREFETCH, PARCOUNT, "basements decompressed for prefetch", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_NUM_BASEMENTS_DECOMPRESSED_WRITE,       BASEMENTS_DECOMPRESSED_FOR_WRITE, PARCOUNT, "basements decompressed for write", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_NUM_MSG_BUFFER_DECOMPRESSED_NORMAL,     BUFFERS_DECOMPRESSED_TARGET_QUERY, PARCOUNT, "buffers decompressed as a target of a query", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_NUM_MSG_BUFFER_DECOMPRESSED_AGGRESSIVE, BUFFERS_DECOMPRESSED_PRELOCKED_RANGE, PARCOUNT, "buffers decompressed for prelocked range", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_NUM_MSG_BUFFER_DECOMPRESSED_PREFETCH,   BUFFERS_DECOMPRESSED_PREFETCH, PARCOUNT, "buffers decompressed for prefetch", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_NUM_MSG_BUFFER_DECOMPRESSED_WRITE,      BUFFERS_DECOMPRESSED_FOR_WRITE, PARCOUNT, "buffers decompressed for write", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-
-    // Eviction statistics:
-    STATUS_INIT(FT_FULL_EVICTIONS_LEAF,                    LEAF_NODE_FULL_EVICTIONS, PARCOUNT, "leaf node full evictions", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_FULL_EVICTIONS_LEAF_BYTES,              LEAF_NODE_FULL_EVICTIONS_BYTES, PARCOUNT, "leaf node full evictions (bytes)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_FULL_EVICTIONS_NONLEAF,                 NONLEAF_NODE_FULL_EVICTIONS, PARCOUNT, "nonleaf node full evictions", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_FULL_EVICTIONS_NONLEAF_BYTES,           NONLEAF_NODE_FULL_EVICTIONS_BYTES, PARCOUNT, "nonleaf node full evictions (bytes)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_PARTIAL_EVICTIONS_LEAF,                 LEAF_NODE_PARTIAL_EVICTIONS, PARCOUNT, "leaf node partial evictions", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_PARTIAL_EVICTIONS_LEAF_BYTES,           LEAF_NODE_PARTIAL_EVICTIONS_BYTES, PARCOUNT, "leaf node partial evictions (bytes)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_PARTIAL_EVICTIONS_NONLEAF,              NONLEAF_NODE_PARTIAL_EVICTIONS, PARCOUNT, "nonleaf node partial evictions", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_PARTIAL_EVICTIONS_NONLEAF_BYTES,        NONLEAF_NODE_PARTIAL_EVICTIONS_BYTES, PARCOUNT, "nonleaf node partial evictions (bytes)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-
-    // Disk read statistics: 
-    //
-    // Pivots: For queries, prefetching, or writing.
-    STATUS_INIT(FT_NUM_PIVOTS_FETCHED_QUERY,               PIVOTS_FETCHED_FOR_QUERY, PARCOUNT, "pivots fetched for query", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_BYTES_PIVOTS_FETCHED_QUERY,             PIVOTS_FETCHED_FOR_QUERY_BYTES, PARCOUNT, "pivots fetched for query (bytes)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_TOKUTIME_PIVOTS_FETCHED_QUERY,          PIVOTS_FETCHED_FOR_QUERY_SECONDS, TOKUTIME, "pivots fetched for query (seconds)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_NUM_PIVOTS_FETCHED_PREFETCH,            PIVOTS_FETCHED_FOR_PREFETCH, PARCOUNT, "pivots fetched for prefetch", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_BYTES_PIVOTS_FETCHED_PREFETCH,          PIVOTS_FETCHED_FOR_PREFETCH_BYTES, PARCOUNT, "pivots fetched for prefetch (bytes)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_TOKUTIME_PIVOTS_FETCHED_PREFETCH,       PIVOTS_FETCHED_FOR_PREFETCH_SECONDS, TOKUTIME, "pivots fetched for prefetch (seconds)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_NUM_PIVOTS_FETCHED_WRITE,               PIVOTS_FETCHED_FOR_WRITE, PARCOUNT, "pivots fetched for write", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_BYTES_PIVOTS_FETCHED_WRITE,             PIVOTS_FETCHED_FOR_WRITE_BYTES, PARCOUNT, "pivots fetched for write (bytes)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_TOKUTIME_PIVOTS_FETCHED_WRITE,          PIVOTS_FETCHED_FOR_WRITE_SECONDS, TOKUTIME, "pivots fetched for write (seconds)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    // Basements: For queries, aggressive fetching in prelocked range, prefetching, or writing.
-    STATUS_INIT(FT_NUM_BASEMENTS_FETCHED_NORMAL,           BASEMENTS_FETCHED_TARGET_QUERY, PARCOUNT, "basements fetched as a target of a query", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_BYTES_BASEMENTS_FETCHED_NORMAL,         BASEMENTS_FETCHED_TARGET_QUERY_BYTES, PARCOUNT, "basements fetched as a target of a query (bytes)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_TOKUTIME_BASEMENTS_FETCHED_NORMAL,      BASEMENTS_FETCHED_TARGET_QUERY_SECONDS, TOKUTIME, "basements fetched as a target of a query (seconds)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_NUM_BASEMENTS_FETCHED_AGGRESSIVE,       BASEMENTS_FETCHED_PRELOCKED_RANGE, PARCOUNT, "basements fetched for prelocked range", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_BYTES_BASEMENTS_FETCHED_AGGRESSIVE,     BASEMENTS_FETCHED_PRELOCKED_RANGE_BYTES, PARCOUNT, "basements fetched for prelocked range (bytes)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_TOKUTIME_BASEMENTS_FETCHED_AGGRESSIVE,  BASEMENTS_FETCHED_PRELOCKED_RANGE_SECONDS, TOKUTIME, "basements fetched for prelocked range (seconds)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_NUM_BASEMENTS_FETCHED_PREFETCH,         BASEMENTS_FETCHED_PREFETCH, PARCOUNT, "basements fetched for prefetch", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_BYTES_BASEMENTS_FETCHED_PREFETCH,       BASEMENTS_FETCHED_PREFETCH_BYTES, PARCOUNT, "basements fetched for prefetch (bytes)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_TOKUTIME_BASEMENTS_FETCHED_PREFETCH,    BASEMENTS_FETCHED_PREFETCH_SECONDS, TOKUTIME, "basements fetched for prefetch (seconds)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_NUM_BASEMENTS_FETCHED_WRITE,            BASEMENTS_FETCHED_FOR_WRITE, PARCOUNT, "basements fetched for write", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_BYTES_BASEMENTS_FETCHED_WRITE,          BASEMENTS_FETCHED_FOR_WRITE_BYTES, PARCOUNT, "basements fetched for write (bytes)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_TOKUTIME_BASEMENTS_FETCHED_WRITE,       BASEMENTS_FETCHED_FOR_WRITE_SECONDS, TOKUTIME, "basements fetched for write (seconds)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    // Buffers: For queries, aggressive fetching in prelocked range, prefetching, or writing.
-    STATUS_INIT(FT_NUM_MSG_BUFFER_FETCHED_NORMAL,          BUFFERS_FETCHED_TARGET_QUERY, PARCOUNT, "buffers fetched as a target of a query", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_BYTES_MSG_BUFFER_FETCHED_NORMAL,        BUFFERS_FETCHED_TARGET_QUERY_BYTES, PARCOUNT, "buffers fetched as a target of a query (bytes)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_TOKUTIME_MSG_BUFFER_FETCHED_NORMAL,     BUFFERS_FETCHED_TARGET_QUERY_SECONDS, TOKUTIME, "buffers fetched as a target of a query (seconds)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_NUM_MSG_BUFFER_FETCHED_AGGRESSIVE,      BUFFERS_FETCHED_PRELOCKED_RANGE, PARCOUNT, "buffers fetched for prelocked range", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_BYTES_MSG_BUFFER_FETCHED_AGGRESSIVE,    BUFFERS_FETCHED_PRELOCKED_RANGE_BYTES, PARCOUNT, "buffers fetched for prelocked range (bytes)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_TOKUTIME_MSG_BUFFER_FETCHED_AGGRESSIVE, BUFFERS_FETCHED_PRELOCKED_RANGE_SECONDS, TOKUTIME, "buffers fetched for prelocked range (seconds)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_NUM_MSG_BUFFER_FETCHED_PREFETCH,        BUFFERS_FETCHED_PREFETCH, PARCOUNT, "buffers fetched for prefetch", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_BYTES_MSG_BUFFER_FETCHED_PREFETCH,      BUFFERS_FETCHED_PREFETCH_BYTES, PARCOUNT, "buffers fetched for prefetch (bytes)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_TOKUTIME_MSG_BUFFER_FETCHED_PREFETCH,   BUFFERS_FETCHED_PREFETCH_SECONDS, TOKUTIME, "buffers fetched for prefetch (seconds)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_NUM_MSG_BUFFER_FETCHED_WRITE,           BUFFERS_FETCHED_FOR_WRITE, PARCOUNT, "buffers fetched for write", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_BYTES_MSG_BUFFER_FETCHED_WRITE,         BUFFERS_FETCHED_FOR_WRITE_BYTES, PARCOUNT, "buffers fetched for write (bytes)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_TOKUTIME_MSG_BUFFER_FETCHED_WRITE,      BUFFERS_FETCHED_FOR_WRITE_SECONDS, TOKUTIME, "buffers fetched for write (seconds)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-
-    // Disk write statistics.
-    //
-    // Leaf/Nonleaf: Not for checkpoint
-    STATUS_INIT(FT_DISK_FLUSH_LEAF,                                         LEAF_NODES_FLUSHED_NOT_CHECKPOINT, PARCOUNT, "leaf nodes flushed to disk (not for checkpoint)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_DISK_FLUSH_LEAF_BYTES,                                   LEAF_NODES_FLUSHED_NOT_CHECKPOINT_BYTES, PARCOUNT, "leaf nodes flushed to disk (not for checkpoint) (bytes)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_DISK_FLUSH_LEAF_UNCOMPRESSED_BYTES,                      LEAF_NODES_FLUSHED_NOT_CHECKPOINT_UNCOMPRESSED_BYTES, PARCOUNT, "leaf nodes flushed to disk (not for checkpoint) (uncompressed bytes)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_DISK_FLUSH_LEAF_TOKUTIME,                                LEAF_NODES_FLUSHED_NOT_CHECKPOINT_SECONDS, TOKUTIME, "leaf nodes flushed to disk (not for checkpoint) (seconds)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_DISK_FLUSH_NONLEAF,                                      NONLEAF_NODES_FLUSHED_TO_DISK_NOT_CHECKPOINT, PARCOUNT, "nonleaf nodes flushed to disk (not for checkpoint)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_DISK_FLUSH_NONLEAF_BYTES,                                NONLEAF_NODES_FLUSHED_TO_DISK_NOT_CHECKPOINT_BYTES, PARCOUNT, "nonleaf nodes flushed to disk (not for checkpoint) (bytes)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_DISK_FLUSH_NONLEAF_UNCOMPRESSED_BYTES,                   NONLEAF_NODES_FLUSHED_TO_DISK_NOT_CHECKPOINT_UNCOMPRESSED_BYTES, PARCOUNT, "nonleaf nodes flushed to disk (not for checkpoint) (uncompressed bytes)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_DISK_FLUSH_NONLEAF_TOKUTIME,                             NONLEAF_NODES_FLUSHED_TO_DISK_NOT_CHECKPOINT_SECONDS, TOKUTIME, "nonleaf nodes flushed to disk (not for checkpoint) (seconds)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    // Leaf/Nonleaf: For checkpoint
-    STATUS_INIT(FT_DISK_FLUSH_LEAF_FOR_CHECKPOINT,                          LEAF_NODES_FLUSHED_CHECKPOINT, PARCOUNT, "leaf nodes flushed to disk (for checkpoint)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_DISK_FLUSH_LEAF_BYTES_FOR_CHECKPOINT,                    LEAF_NODES_FLUSHED_CHECKPOINT_BYTES, PARCOUNT, "leaf nodes flushed to disk (for checkpoint) (bytes)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_DISK_FLUSH_LEAF_UNCOMPRESSED_BYTES_FOR_CHECKPOINT,       LEAF_NODES_FLUSHED_CHECKPOINT_UNCOMPRESSED_BYTES, PARCOUNT, "leaf nodes flushed to disk (for checkpoint) (uncompressed bytes)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_DISK_FLUSH_LEAF_TOKUTIME_FOR_CHECKPOINT,                 LEAF_NODES_FLUSHED_CHECKPOINT_SECONDS, TOKUTIME, "leaf nodes flushed to disk (for checkpoint) (seconds)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_DISK_FLUSH_NONLEAF_FOR_CHECKPOINT,                       NONLEAF_NODES_FLUSHED_TO_DISK_CHECKPOINT, PARCOUNT, "nonleaf nodes flushed to disk (for checkpoint)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_DISK_FLUSH_NONLEAF_BYTES_FOR_CHECKPOINT,                 NONLEAF_NODES_FLUSHED_TO_DISK_CHECKPOINT_BYTES, PARCOUNT, "nonleaf nodes flushed to disk (for checkpoint) (bytes)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_DISK_FLUSH_NONLEAF_UNCOMPRESSED_BYTES_FOR_CHECKPOINT,    NONLEAF_NODES_FLUSHED_TO_DISK_CHECKPOINT_UNCOMPRESSED_BYTES, PARCOUNT, "nonleaf nodes flushed to disk (for checkpoint) (uncompressed bytes)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_DISK_FLUSH_NONLEAF_TOKUTIME_FOR_CHECKPOINT,              NONLEAF_NODES_FLUSHED_TO_DISK_CHECKPOINT_SECONDS, TOKUTIME, "nonleaf nodes flushed to disk (for checkpoint) (seconds)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_DISK_FLUSH_LEAF_COMPRESSION_RATIO,                       LEAF_NODE_COMPRESSION_RATIO, DOUBLE, "uncompressed / compressed bytes written (leaf)", TOKU_GLOBAL_STATUS|TOKU_ENGINE_STATUS);
-    STATUS_INIT(FT_DISK_FLUSH_NONLEAF_COMPRESSION_RATIO,                    NONLEAF_NODE_COMPRESSION_RATIO, DOUBLE, "uncompressed / compressed bytes written (nonleaf)", TOKU_GLOBAL_STATUS|TOKU_ENGINE_STATUS);
-    STATUS_INIT(FT_DISK_FLUSH_OVERALL_COMPRESSION_RATIO,                    OVERALL_NODE_COMPRESSION_RATIO, DOUBLE, "uncompressed / compressed bytes written (overall)", TOKU_GLOBAL_STATUS|TOKU_ENGINE_STATUS);
-
-    // CPU time statistics for [de]serialization and [de]compression.
-    STATUS_INIT(FT_LEAF_COMPRESS_TOKUTIME,                                  LEAF_COMPRESSION_TO_MEMORY_SECONDS, TOKUTIME, "leaf compression to memory (seconds)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_LEAF_SERIALIZE_TOKUTIME,                                 LEAF_SERIALIZATION_TO_MEMORY_SECONDS, TOKUTIME, "leaf serialization to memory (seconds)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_LEAF_DECOMPRESS_TOKUTIME,                                LEAF_DECOMPRESSION_TO_MEMORY_SECONDS, TOKUTIME, "leaf decompression to memory (seconds)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_LEAF_DESERIALIZE_TOKUTIME,                               LEAF_DESERIALIZATION_TO_MEMORY_SECONDS, TOKUTIME, "leaf deserialization to memory (seconds)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_NONLEAF_COMPRESS_TOKUTIME,                               NONLEAF_COMPRESSION_TO_MEMORY_SECONDS, TOKUTIME, "nonleaf compression to memory (seconds)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_NONLEAF_SERIALIZE_TOKUTIME,                              NONLEAF_SERIALIZATION_TO_MEMORY_SECONDS, TOKUTIME, "nonleaf serialization to memory (seconds)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_NONLEAF_DECOMPRESS_TOKUTIME,                             NONLEAF_DECOMPRESSION_TO_MEMORY_SECONDS, TOKUTIME, "nonleaf decompression to memory (seconds)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_NONLEAF_DESERIALIZE_TOKUTIME,                            NONLEAF_DESERIALIZATION_TO_MEMORY_SECONDS, TOKUTIME, "nonleaf deserialization to memory (seconds)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-
-    // Promotion statistics.
-    STATUS_INIT(FT_PRO_NUM_ROOT_SPLIT,                     PROMOTION_ROOTS_SPLIT, PARCOUNT, "promotion: roots split", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_PRO_NUM_ROOT_H0_INJECT,                 PROMOTION_LEAF_ROOTS_INJECTED_INTO, PARCOUNT, "promotion: leaf roots injected into", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_PRO_NUM_ROOT_H1_INJECT,                 PROMOTION_H1_ROOTS_INJECTED_INTO, PARCOUNT, "promotion: h1 roots injected into", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_PRO_NUM_INJECT_DEPTH_0,                 PROMOTION_INJECTIONS_AT_DEPTH_0, PARCOUNT, "promotion: injections at depth 0", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_PRO_NUM_INJECT_DEPTH_1,                 PROMOTION_INJECTIONS_AT_DEPTH_1, PARCOUNT, "promotion: injections at depth 1", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_PRO_NUM_INJECT_DEPTH_2,                 PROMOTION_INJECTIONS_AT_DEPTH_2, PARCOUNT, "promotion: injections at depth 2", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_PRO_NUM_INJECT_DEPTH_3,                 PROMOTION_INJECTIONS_AT_DEPTH_3, PARCOUNT, "promotion: injections at depth 3", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_PRO_NUM_INJECT_DEPTH_GT3,               PROMOTION_INJECTIONS_LOWER_THAN_DEPTH_3, PARCOUNT, "promotion: injections lower than depth 3", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_PRO_NUM_STOP_NONEMPTY_BUF,              PROMOTION_STOPPED_NONEMPTY_BUFFER, PARCOUNT, "promotion: stopped because of a nonempty buffer", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_PRO_NUM_STOP_H1,                        PROMOTION_STOPPED_AT_HEIGHT_1, PARCOUNT, "promotion: stopped at height 1", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_PRO_NUM_STOP_LOCK_CHILD,                PROMOTION_STOPPED_CHILD_LOCKED_OR_NOT_IN_MEMORY, PARCOUNT, "promotion: stopped because the child was locked or not at all in memory", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_PRO_NUM_STOP_CHILD_INMEM,               PROMOTION_STOPPED_CHILD_NOT_FULLY_IN_MEMORY, PARCOUNT, "promotion: stopped because the child was not fully in memory", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_PRO_NUM_DIDNT_WANT_PROMOTE,             PROMOTION_STOPPED_AFTER_LOCKING_CHILD, PARCOUNT, "promotion: stopped anyway, after locking the child", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_BASEMENT_DESERIALIZE_FIXED_KEYSIZE,     BASEMENT_DESERIALIZATION_FIXED_KEY, PARCOUNT, "basement nodes deserialized with fixed-keysize", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_BASEMENT_DESERIALIZE_VARIABLE_KEYSIZE,  BASEMENT_DESERIALIZATION_VARIABLE_KEY, PARCOUNT, "basement nodes deserialized with variable-keysize", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(FT_PRO_RIGHTMOST_LEAF_SHORTCUT_SUCCESS,    nullptr, PARCOUNT, "promotion: succeeded in using the rightmost leaf shortcut", TOKU_ENGINE_STATUS);
-    STATUS_INIT(FT_PRO_RIGHTMOST_LEAF_SHORTCUT_FAIL_POS,   nullptr, PARCOUNT, "promotion: tried the rightmost leaf shorcut but failed (out-of-bounds)", TOKU_ENGINE_STATUS);
-    STATUS_INIT(FT_PRO_RIGHTMOST_LEAF_SHORTCUT_FAIL_REACTIVE,nullptr, PARCOUNT, "promotion: tried the rightmost leaf shorcut but failed (child reactive)", TOKU_ENGINE_STATUS);
-
-    STATUS_INIT(FT_CURSOR_SKIP_DELETED_LEAF_ENTRY,         CURSOR_SKIP_DELETED_LEAF_ENTRY, PARCOUNT, "cursor skipped deleted leaf entries", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-
-    ft_status.initialized = true;
-}
-static void status_destroy(void) {
-    for (int i = 0; i < FT_STATUS_NUM_ROWS; ++i) {
-        if (ft_status.status[i].type == PARCOUNT) {
-            destroy_partitioned_counter(ft_status.status[i].value.parcount);
-        }
-    }
-}
-#undef STATUS_INIT
-
-#define STATUS_VAL(x)                                                               \
-    (ft_status.status[x].type == PARCOUNT ?                                         \
-        read_partitioned_counter(ft_status.status[x].value.parcount) :              \
-        ft_status.status[x].value.num)
-
 void
 toku_ft_get_status(FT_STATUS s) {
+    ft_status.init();
     *s = ft_status;
 
     // Calculate compression ratios for leaf and nonleaf nodes
-    const double compressed_leaf_bytes = STATUS_VAL(FT_DISK_FLUSH_LEAF_BYTES) +
-                                         STATUS_VAL(FT_DISK_FLUSH_LEAF_BYTES_FOR_CHECKPOINT);
-    const double uncompressed_leaf_bytes = STATUS_VAL(FT_DISK_FLUSH_LEAF_UNCOMPRESSED_BYTES) +
-                                           STATUS_VAL(FT_DISK_FLUSH_LEAF_UNCOMPRESSED_BYTES_FOR_CHECKPOINT);
-    const double compressed_nonleaf_bytes = STATUS_VAL(FT_DISK_FLUSH_NONLEAF_BYTES) +
-                                            STATUS_VAL(FT_DISK_FLUSH_NONLEAF_BYTES_FOR_CHECKPOINT);
-    const double uncompressed_nonleaf_bytes = STATUS_VAL(FT_DISK_FLUSH_NONLEAF_UNCOMPRESSED_BYTES) +
-                                              STATUS_VAL(FT_DISK_FLUSH_NONLEAF_UNCOMPRESSED_BYTES_FOR_CHECKPOINT);
+    const double compressed_leaf_bytes = FT_STATUS_VAL(FT_DISK_FLUSH_LEAF_BYTES) +
+                                         FT_STATUS_VAL(FT_DISK_FLUSH_LEAF_BYTES_FOR_CHECKPOINT);
+    const double uncompressed_leaf_bytes = FT_STATUS_VAL(FT_DISK_FLUSH_LEAF_UNCOMPRESSED_BYTES) +
+                                           FT_STATUS_VAL(FT_DISK_FLUSH_LEAF_UNCOMPRESSED_BYTES_FOR_CHECKPOINT);
+    const double compressed_nonleaf_bytes = FT_STATUS_VAL(FT_DISK_FLUSH_NONLEAF_BYTES) +
+                                            FT_STATUS_VAL(FT_DISK_FLUSH_NONLEAF_BYTES_FOR_CHECKPOINT);
+    const double uncompressed_nonleaf_bytes = FT_STATUS_VAL(FT_DISK_FLUSH_NONLEAF_UNCOMPRESSED_BYTES) +
+                                              FT_STATUS_VAL(FT_DISK_FLUSH_NONLEAF_UNCOMPRESSED_BYTES_FOR_CHECKPOINT);
 
     if (compressed_leaf_bytes > 0) {
-        s->status[FT_DISK_FLUSH_LEAF_COMPRESSION_RATIO].value.dnum = uncompressed_leaf_bytes / compressed_leaf_bytes;
+        s->status[FT_STATUS_S::FT_DISK_FLUSH_LEAF_COMPRESSION_RATIO].value.dnum
+            = uncompressed_leaf_bytes / compressed_leaf_bytes;
     }
     if (compressed_nonleaf_bytes > 0) {
-        s->status[FT_DISK_FLUSH_NONLEAF_COMPRESSION_RATIO].value.dnum = uncompressed_nonleaf_bytes / compressed_nonleaf_bytes;
+        s->status[FT_STATUS_S::FT_DISK_FLUSH_NONLEAF_COMPRESSION_RATIO].value.dnum
+            = uncompressed_nonleaf_bytes / compressed_nonleaf_bytes;
     }
     if (compressed_leaf_bytes > 0 || compressed_nonleaf_bytes > 0) {
-        s->status[FT_DISK_FLUSH_OVERALL_COMPRESSION_RATIO].value.dnum =
-            (uncompressed_leaf_bytes + uncompressed_nonleaf_bytes) / (compressed_leaf_bytes + compressed_nonleaf_bytes);
+        s->status[FT_STATUS_S::FT_DISK_FLUSH_OVERALL_COMPRESSION_RATIO].value.dnum
+            = (uncompressed_leaf_bytes + uncompressed_nonleaf_bytes) /
+              (compressed_leaf_bytes + compressed_nonleaf_bytes);
     }
 }
 
-#define STATUS_INC(x, d)                                                            \
-    do {                                                                            \
-        if (ft_status.status[x].type == PARCOUNT) {                                 \
-            increment_partitioned_counter(ft_status.status[x].value.parcount, d);   \
-        } else {                                                                    \
-            toku_sync_fetch_and_add(&ft_status.status[x].value.num, d);             \
-        }                                                                           \
-    } while (0)
-
-
 void toku_note_deserialized_basement_node(bool fixed_key_size) {
     if (fixed_key_size) {
-        STATUS_INC(FT_BASEMENT_DESERIALIZE_FIXED_KEYSIZE, 1);
+        FT_STATUS_INC(FT_BASEMENT_DESERIALIZE_FIXED_KEYSIZE, 1);
     } else {
-        STATUS_INC(FT_BASEMENT_DESERIALIZE_VARIABLE_KEYSIZE, 1);
+        FT_STATUS_INC(FT_BASEMENT_DESERIALIZE_VARIABLE_KEYSIZE, 1);
     }
 }
 
@@ -771,30 +610,30 @@ void toku_ft_status_update_flush_reason(FTNODE node,
         tokutime_t write_time, bool for_checkpoint) {
     if (node->height == 0) {
         if (for_checkpoint) {
-            STATUS_INC(FT_DISK_FLUSH_LEAF_FOR_CHECKPOINT, 1);
-            STATUS_INC(FT_DISK_FLUSH_LEAF_BYTES_FOR_CHECKPOINT, bytes_written);
-            STATUS_INC(FT_DISK_FLUSH_LEAF_UNCOMPRESSED_BYTES_FOR_CHECKPOINT, uncompressed_bytes_flushed);
-            STATUS_INC(FT_DISK_FLUSH_LEAF_TOKUTIME_FOR_CHECKPOINT, write_time);
+            FT_STATUS_INC(FT_DISK_FLUSH_LEAF_FOR_CHECKPOINT, 1);
+            FT_STATUS_INC(FT_DISK_FLUSH_LEAF_BYTES_FOR_CHECKPOINT, bytes_written);
+            FT_STATUS_INC(FT_DISK_FLUSH_LEAF_UNCOMPRESSED_BYTES_FOR_CHECKPOINT, uncompressed_bytes_flushed);
+            FT_STATUS_INC(FT_DISK_FLUSH_LEAF_TOKUTIME_FOR_CHECKPOINT, write_time);
         }
         else {
-            STATUS_INC(FT_DISK_FLUSH_LEAF, 1);
-            STATUS_INC(FT_DISK_FLUSH_LEAF_BYTES, bytes_written);
-            STATUS_INC(FT_DISK_FLUSH_LEAF_UNCOMPRESSED_BYTES, uncompressed_bytes_flushed);
-            STATUS_INC(FT_DISK_FLUSH_LEAF_TOKUTIME, write_time);
+            FT_STATUS_INC(FT_DISK_FLUSH_LEAF, 1);
+            FT_STATUS_INC(FT_DISK_FLUSH_LEAF_BYTES, bytes_written);
+            FT_STATUS_INC(FT_DISK_FLUSH_LEAF_UNCOMPRESSED_BYTES, uncompressed_bytes_flushed);
+            FT_STATUS_INC(FT_DISK_FLUSH_LEAF_TOKUTIME, write_time);
         }
     }
     else {
         if (for_checkpoint) {
-            STATUS_INC(FT_DISK_FLUSH_NONLEAF_FOR_CHECKPOINT, 1);
-            STATUS_INC(FT_DISK_FLUSH_NONLEAF_BYTES_FOR_CHECKPOINT, bytes_written);
-            STATUS_INC(FT_DISK_FLUSH_NONLEAF_UNCOMPRESSED_BYTES_FOR_CHECKPOINT, uncompressed_bytes_flushed);
-            STATUS_INC(FT_DISK_FLUSH_NONLEAF_TOKUTIME_FOR_CHECKPOINT, write_time);
+            FT_STATUS_INC(FT_DISK_FLUSH_NONLEAF_FOR_CHECKPOINT, 1);
+            FT_STATUS_INC(FT_DISK_FLUSH_NONLEAF_BYTES_FOR_CHECKPOINT, bytes_written);
+            FT_STATUS_INC(FT_DISK_FLUSH_NONLEAF_UNCOMPRESSED_BYTES_FOR_CHECKPOINT, uncompressed_bytes_flushed);
+            FT_STATUS_INC(FT_DISK_FLUSH_NONLEAF_TOKUTIME_FOR_CHECKPOINT, write_time);
         }
         else {
-            STATUS_INC(FT_DISK_FLUSH_NONLEAF, 1);
-            STATUS_INC(FT_DISK_FLUSH_NONLEAF_BYTES, bytes_written);
-            STATUS_INC(FT_DISK_FLUSH_NONLEAF_UNCOMPRESSED_BYTES, uncompressed_bytes_flushed);
-            STATUS_INC(FT_DISK_FLUSH_NONLEAF_TOKUTIME, write_time);
+            FT_STATUS_INC(FT_DISK_FLUSH_NONLEAF, 1);
+            FT_STATUS_INC(FT_DISK_FLUSH_NONLEAF_BYTES, bytes_written);
+            FT_STATUS_INC(FT_DISK_FLUSH_NONLEAF_UNCOMPRESSED_BYTES, uncompressed_bytes_flushed);
+            FT_STATUS_INC(FT_DISK_FLUSH_NONLEAF_TOKUTIME, write_time);
         }
     }
 }
@@ -910,11 +749,11 @@ void toku_ftnode_flush_callback(
         if (!is_clone) {
             long node_size = ftnode_memory_size(ftnode);
             if (ftnode->height == 0) {
-                STATUS_INC(FT_FULL_EVICTIONS_LEAF, 1);
-                STATUS_INC(FT_FULL_EVICTIONS_LEAF_BYTES, node_size);
+                FT_STATUS_INC(FT_FULL_EVICTIONS_LEAF, 1);
+                FT_STATUS_INC(FT_FULL_EVICTIONS_LEAF_BYTES, node_size);
             } else {
-                STATUS_INC(FT_FULL_EVICTIONS_NONLEAF, 1);
-                STATUS_INC(FT_FULL_EVICTIONS_NONLEAF_BYTES, node_size);
+                FT_STATUS_INC(FT_FULL_EVICTIONS_NONLEAF, 1);
+                FT_STATUS_INC(FT_FULL_EVICTIONS_NONLEAF_BYTES, node_size);
             }
             toku_free(*disk_data);
         }
@@ -939,17 +778,17 @@ void
 toku_ft_status_update_pivot_fetch_reason(ftnode_fetch_extra *bfe)
 {
     if (bfe->type == ftnode_fetch_prefetch) {
-        STATUS_INC(FT_NUM_PIVOTS_FETCHED_PREFETCH, 1);
-        STATUS_INC(FT_BYTES_PIVOTS_FETCHED_PREFETCH, bfe->bytes_read);
-        STATUS_INC(FT_TOKUTIME_PIVOTS_FETCHED_PREFETCH, bfe->io_time);
+        FT_STATUS_INC(FT_NUM_PIVOTS_FETCHED_PREFETCH, 1);
+        FT_STATUS_INC(FT_BYTES_PIVOTS_FETCHED_PREFETCH, bfe->bytes_read);
+        FT_STATUS_INC(FT_TOKUTIME_PIVOTS_FETCHED_PREFETCH, bfe->io_time);
     } else if (bfe->type == ftnode_fetch_all) {
-        STATUS_INC(FT_NUM_PIVOTS_FETCHED_WRITE, 1);
-        STATUS_INC(FT_BYTES_PIVOTS_FETCHED_WRITE, bfe->bytes_read);
-        STATUS_INC(FT_TOKUTIME_PIVOTS_FETCHED_WRITE, bfe->io_time);
+        FT_STATUS_INC(FT_NUM_PIVOTS_FETCHED_WRITE, 1);
+        FT_STATUS_INC(FT_BYTES_PIVOTS_FETCHED_WRITE, bfe->bytes_read);
+        FT_STATUS_INC(FT_TOKUTIME_PIVOTS_FETCHED_WRITE, bfe->io_time);
     } else if (bfe->type == ftnode_fetch_subset || bfe->type == ftnode_fetch_keymatch) {
-        STATUS_INC(FT_NUM_PIVOTS_FETCHED_QUERY, 1);
-        STATUS_INC(FT_BYTES_PIVOTS_FETCHED_QUERY, bfe->bytes_read);
-        STATUS_INC(FT_TOKUTIME_PIVOTS_FETCHED_QUERY, bfe->io_time);
+        FT_STATUS_INC(FT_NUM_PIVOTS_FETCHED_QUERY, 1);
+        FT_STATUS_INC(FT_BYTES_PIVOTS_FETCHED_QUERY, bfe->bytes_read);
+        FT_STATUS_INC(FT_TOKUTIME_PIVOTS_FETCHED_QUERY, bfe->io_time);
     }
 }
 
@@ -1185,12 +1024,12 @@ exit:
     if (num_partial_evictions > 0) {
         if (height == 0) {
             long delta = old_attr.leaf_size - new_attr.leaf_size;
-            STATUS_INC(FT_PARTIAL_EVICTIONS_LEAF, num_partial_evictions);
-            STATUS_INC(FT_PARTIAL_EVICTIONS_LEAF_BYTES, delta);
+            FT_STATUS_INC(FT_PARTIAL_EVICTIONS_LEAF, num_partial_evictions);
+            FT_STATUS_INC(FT_PARTIAL_EVICTIONS_LEAF_BYTES, delta);
         } else {
             long delta = old_attr.nonleaf_size - new_attr.nonleaf_size;
-            STATUS_INC(FT_PARTIAL_EVICTIONS_NONLEAF, num_partial_evictions);
-            STATUS_INC(FT_PARTIAL_EVICTIONS_NONLEAF_BYTES, delta);
+            FT_STATUS_INC(FT_PARTIAL_EVICTIONS_NONLEAF, num_partial_evictions);
+            FT_STATUS_INC(FT_PARTIAL_EVICTIONS_NONLEAF_BYTES, delta);
         }
     }
     return 0;
@@ -1304,70 +1143,70 @@ ft_status_update_partial_fetch_reason(
     if (is_leaf) {
         if (bfe->type == ftnode_fetch_prefetch) {
             if (state == PT_COMPRESSED) {
-                STATUS_INC(FT_NUM_BASEMENTS_DECOMPRESSED_PREFETCH, 1);
+                FT_STATUS_INC(FT_NUM_BASEMENTS_DECOMPRESSED_PREFETCH, 1);
             } else {
-                STATUS_INC(FT_NUM_BASEMENTS_FETCHED_PREFETCH, 1);
-                STATUS_INC(FT_BYTES_BASEMENTS_FETCHED_PREFETCH, bfe->bytes_read);
-                STATUS_INC(FT_TOKUTIME_BASEMENTS_FETCHED_PREFETCH, bfe->io_time);
+                FT_STATUS_INC(FT_NUM_BASEMENTS_FETCHED_PREFETCH, 1);
+                FT_STATUS_INC(FT_BYTES_BASEMENTS_FETCHED_PREFETCH, bfe->bytes_read);
+                FT_STATUS_INC(FT_TOKUTIME_BASEMENTS_FETCHED_PREFETCH, bfe->io_time);
             }
         } else if (bfe->type == ftnode_fetch_all) {
             if (state == PT_COMPRESSED) {
-                STATUS_INC(FT_NUM_BASEMENTS_DECOMPRESSED_WRITE, 1);
+                FT_STATUS_INC(FT_NUM_BASEMENTS_DECOMPRESSED_WRITE, 1);
             } else {
-                STATUS_INC(FT_NUM_BASEMENTS_FETCHED_WRITE, 1);
-                STATUS_INC(FT_BYTES_BASEMENTS_FETCHED_WRITE, bfe->bytes_read);
-                STATUS_INC(FT_TOKUTIME_BASEMENTS_FETCHED_WRITE, bfe->io_time);
+                FT_STATUS_INC(FT_NUM_BASEMENTS_FETCHED_WRITE, 1);
+                FT_STATUS_INC(FT_BYTES_BASEMENTS_FETCHED_WRITE, bfe->bytes_read);
+                FT_STATUS_INC(FT_TOKUTIME_BASEMENTS_FETCHED_WRITE, bfe->io_time);
             }
         } else if (childnum == bfe->child_to_read) {
             if (state == PT_COMPRESSED) {
-                STATUS_INC(FT_NUM_BASEMENTS_DECOMPRESSED_NORMAL, 1);
+                FT_STATUS_INC(FT_NUM_BASEMENTS_DECOMPRESSED_NORMAL, 1);
             } else {
-                STATUS_INC(FT_NUM_BASEMENTS_FETCHED_NORMAL, 1);
-                STATUS_INC(FT_BYTES_BASEMENTS_FETCHED_NORMAL, bfe->bytes_read);
-                STATUS_INC(FT_TOKUTIME_BASEMENTS_FETCHED_NORMAL, bfe->io_time);
+                FT_STATUS_INC(FT_NUM_BASEMENTS_FETCHED_NORMAL, 1);
+                FT_STATUS_INC(FT_BYTES_BASEMENTS_FETCHED_NORMAL, bfe->bytes_read);
+                FT_STATUS_INC(FT_TOKUTIME_BASEMENTS_FETCHED_NORMAL, bfe->io_time);
             }
         } else {
             if (state == PT_COMPRESSED) {
-                STATUS_INC(FT_NUM_BASEMENTS_DECOMPRESSED_AGGRESSIVE, 1);
+                FT_STATUS_INC(FT_NUM_BASEMENTS_DECOMPRESSED_AGGRESSIVE, 1);
             } else {
-                STATUS_INC(FT_NUM_BASEMENTS_FETCHED_AGGRESSIVE, 1);
-                STATUS_INC(FT_BYTES_BASEMENTS_FETCHED_AGGRESSIVE, bfe->bytes_read);
-                STATUS_INC(FT_TOKUTIME_BASEMENTS_FETCHED_AGGRESSIVE, bfe->io_time);
+                FT_STATUS_INC(FT_NUM_BASEMENTS_FETCHED_AGGRESSIVE, 1);
+                FT_STATUS_INC(FT_BYTES_BASEMENTS_FETCHED_AGGRESSIVE, bfe->bytes_read);
+                FT_STATUS_INC(FT_TOKUTIME_BASEMENTS_FETCHED_AGGRESSIVE, bfe->io_time);
             }
         }
     }
     else {
         if (bfe->type == ftnode_fetch_prefetch) {
             if (state == PT_COMPRESSED) {
-                STATUS_INC(FT_NUM_MSG_BUFFER_DECOMPRESSED_PREFETCH, 1);
+                FT_STATUS_INC(FT_NUM_MSG_BUFFER_DECOMPRESSED_PREFETCH, 1);
             } else {
-                STATUS_INC(FT_NUM_MSG_BUFFER_FETCHED_PREFETCH, 1);
-                STATUS_INC(FT_BYTES_MSG_BUFFER_FETCHED_PREFETCH, bfe->bytes_read);
-                STATUS_INC(FT_TOKUTIME_MSG_BUFFER_FETCHED_PREFETCH, bfe->io_time);
+                FT_STATUS_INC(FT_NUM_MSG_BUFFER_FETCHED_PREFETCH, 1);
+                FT_STATUS_INC(FT_BYTES_MSG_BUFFER_FETCHED_PREFETCH, bfe->bytes_read);
+                FT_STATUS_INC(FT_TOKUTIME_MSG_BUFFER_FETCHED_PREFETCH, bfe->io_time);
             }
         } else if (bfe->type == ftnode_fetch_all) {
             if (state == PT_COMPRESSED) {
-                STATUS_INC(FT_NUM_MSG_BUFFER_DECOMPRESSED_WRITE, 1);
+                FT_STATUS_INC(FT_NUM_MSG_BUFFER_DECOMPRESSED_WRITE, 1);
             } else {
-                STATUS_INC(FT_NUM_MSG_BUFFER_FETCHED_WRITE, 1);
-                STATUS_INC(FT_BYTES_MSG_BUFFER_FETCHED_WRITE, bfe->bytes_read);
-                STATUS_INC(FT_TOKUTIME_MSG_BUFFER_FETCHED_WRITE, bfe->io_time);
+                FT_STATUS_INC(FT_NUM_MSG_BUFFER_FETCHED_WRITE, 1);
+                FT_STATUS_INC(FT_BYTES_MSG_BUFFER_FETCHED_WRITE, bfe->bytes_read);
+                FT_STATUS_INC(FT_TOKUTIME_MSG_BUFFER_FETCHED_WRITE, bfe->io_time);
             }
         } else if (childnum == bfe->child_to_read) {
             if (state == PT_COMPRESSED) {
-                STATUS_INC(FT_NUM_MSG_BUFFER_DECOMPRESSED_NORMAL, 1);
+                FT_STATUS_INC(FT_NUM_MSG_BUFFER_DECOMPRESSED_NORMAL, 1);
             } else {
-                STATUS_INC(FT_NUM_MSG_BUFFER_FETCHED_NORMAL, 1);
-                STATUS_INC(FT_BYTES_MSG_BUFFER_FETCHED_NORMAL, bfe->bytes_read);
-                STATUS_INC(FT_TOKUTIME_MSG_BUFFER_FETCHED_NORMAL, bfe->io_time);
+                FT_STATUS_INC(FT_NUM_MSG_BUFFER_FETCHED_NORMAL, 1);
+                FT_STATUS_INC(FT_BYTES_MSG_BUFFER_FETCHED_NORMAL, bfe->bytes_read);
+                FT_STATUS_INC(FT_TOKUTIME_MSG_BUFFER_FETCHED_NORMAL, bfe->io_time);
             }
         } else {
             if (state == PT_COMPRESSED) {
-                STATUS_INC(FT_NUM_MSG_BUFFER_DECOMPRESSED_AGGRESSIVE, 1);
+                FT_STATUS_INC(FT_NUM_MSG_BUFFER_DECOMPRESSED_AGGRESSIVE, 1);
             } else {
-                STATUS_INC(FT_NUM_MSG_BUFFER_FETCHED_AGGRESSIVE, 1);
-                STATUS_INC(FT_BYTES_MSG_BUFFER_FETCHED_AGGRESSIVE, bfe->bytes_read);
-                STATUS_INC(FT_TOKUTIME_MSG_BUFFER_FETCHED_AGGRESSIVE, bfe->io_time);
+                FT_STATUS_INC(FT_NUM_MSG_BUFFER_FETCHED_AGGRESSIVE, 1);
+                FT_STATUS_INC(FT_BYTES_MSG_BUFFER_FETCHED_AGGRESSIVE, bfe->bytes_read);
+                FT_STATUS_INC(FT_TOKUTIME_MSG_BUFFER_FETCHED_AGGRESSIVE, bfe->io_time);
             }
         }
     }
@@ -1375,46 +1214,46 @@ ft_status_update_partial_fetch_reason(
 
 void toku_ft_status_update_serialize_times(FTNODE node, tokutime_t serialize_time, tokutime_t compress_time) {
     if (node->height == 0) {
-        STATUS_INC(FT_LEAF_SERIALIZE_TOKUTIME, serialize_time);
-        STATUS_INC(FT_LEAF_COMPRESS_TOKUTIME, compress_time);
+        FT_STATUS_INC(FT_LEAF_SERIALIZE_TOKUTIME, serialize_time);
+        FT_STATUS_INC(FT_LEAF_COMPRESS_TOKUTIME, compress_time);
     } else {
-        STATUS_INC(FT_NONLEAF_SERIALIZE_TOKUTIME, serialize_time);
-        STATUS_INC(FT_NONLEAF_COMPRESS_TOKUTIME, compress_time);
+        FT_STATUS_INC(FT_NONLEAF_SERIALIZE_TOKUTIME, serialize_time);
+        FT_STATUS_INC(FT_NONLEAF_COMPRESS_TOKUTIME, compress_time);
     }
 }
 
 void toku_ft_status_update_deserialize_times(FTNODE node, tokutime_t deserialize_time, tokutime_t decompress_time) {
     if (node->height == 0) {
-        STATUS_INC(FT_LEAF_DESERIALIZE_TOKUTIME, deserialize_time);
-        STATUS_INC(FT_LEAF_DECOMPRESS_TOKUTIME, decompress_time);
+        FT_STATUS_INC(FT_LEAF_DESERIALIZE_TOKUTIME, deserialize_time);
+        FT_STATUS_INC(FT_LEAF_DECOMPRESS_TOKUTIME, decompress_time);
     } else {
-        STATUS_INC(FT_NONLEAF_DESERIALIZE_TOKUTIME, deserialize_time);
-        STATUS_INC(FT_NONLEAF_DECOMPRESS_TOKUTIME, decompress_time);
+        FT_STATUS_INC(FT_NONLEAF_DESERIALIZE_TOKUTIME, deserialize_time);
+        FT_STATUS_INC(FT_NONLEAF_DECOMPRESS_TOKUTIME, decompress_time);
     }
 }
 
 void toku_ft_status_note_msn_discard(void) {
-    STATUS_INC(FT_MSN_DISCARDS, 1);
+    FT_STATUS_INC(FT_MSN_DISCARDS, 1);
 }
 
 void toku_ft_status_note_update(bool broadcast) {
     if (broadcast) {
-        STATUS_INC(FT_UPDATES_BROADCAST, 1);
+        FT_STATUS_INC(FT_UPDATES_BROADCAST, 1);
     } else {
-        STATUS_INC(FT_UPDATES, 1);
+        FT_STATUS_INC(FT_UPDATES, 1);
     }
 }
 
 void toku_ft_status_note_msg_bytes_out(size_t buffsize) {
-    STATUS_INC(FT_MSG_BYTES_OUT, buffsize);
-    STATUS_INC(FT_MSG_BYTES_CURR, -buffsize);
+    FT_STATUS_INC(FT_MSG_BYTES_OUT, buffsize);
+    FT_STATUS_INC(FT_MSG_BYTES_CURR, -buffsize);
 }
 void toku_ft_status_note_ftnode(int height, bool created) {
     if (created) {
         if (height == 0) {
-            STATUS_INC(FT_CREATE_LEAF, 1);
+            FT_STATUS_INC(FT_CREATE_LEAF, 1);
         } else {
-            STATUS_INC(FT_CREATE_NONLEAF, 1);
+            FT_STATUS_INC(FT_CREATE_NONLEAF, 1);
         }
     } else {
         // created = false means destroyed
@@ -1610,11 +1449,11 @@ static void inject_message_in_locked_node(
     // update some status variables
     if (node->height != 0) {
         size_t msgsize = msg.total_size();
-        STATUS_INC(FT_MSG_BYTES_IN, msgsize);
-        STATUS_INC(FT_MSG_BYTES_CURR, msgsize);
-        STATUS_INC(FT_MSG_NUM, 1);
+        FT_STATUS_INC(FT_MSG_BYTES_IN, msgsize);
+        FT_STATUS_INC(FT_MSG_BYTES_CURR, msgsize);
+        FT_STATUS_INC(FT_MSG_NUM, 1);
         if (ft_msg_type_applies_all(msg.type())) {
-            STATUS_INC(FT_MSG_NUM_BROADCAST, 1);
+            FT_STATUS_INC(FT_MSG_NUM_BROADCAST, 1);
         }
     }
 
@@ -1845,15 +1684,15 @@ static void push_something_in_subtree(
     if (should_inject_in_node(loc, subtree_root->height, depth)) {
         switch (depth) {
         case 0:
-            STATUS_INC(FT_PRO_NUM_INJECT_DEPTH_0, 1); break;
+            FT_STATUS_INC(FT_PRO_NUM_INJECT_DEPTH_0, 1); break;
         case 1:
-            STATUS_INC(FT_PRO_NUM_INJECT_DEPTH_1, 1); break;
+            FT_STATUS_INC(FT_PRO_NUM_INJECT_DEPTH_1, 1); break;
         case 2:
-            STATUS_INC(FT_PRO_NUM_INJECT_DEPTH_2, 1); break;
+            FT_STATUS_INC(FT_PRO_NUM_INJECT_DEPTH_2, 1); break;
         case 3:
-            STATUS_INC(FT_PRO_NUM_INJECT_DEPTH_3, 1); break;
+            FT_STATUS_INC(FT_PRO_NUM_INJECT_DEPTH_3, 1); break;
         default:
-            STATUS_INC(FT_PRO_NUM_INJECT_DEPTH_GT3, 1); break;
+            FT_STATUS_INC(FT_PRO_NUM_INJECT_DEPTH_GT3, 1); break;
         }
         // If the target node is a non-root leaf node on the right extreme,
         // set the rightmost blocknum. We know there are no messages above us
@@ -1878,7 +1717,7 @@ static void push_something_in_subtree(
 
         if (toku_bnc_n_entries(bnc) > 0) {
             // The buffer is non-empty, give up on promoting.
-            STATUS_INC(FT_PRO_NUM_STOP_NONEMPTY_BUF, 1);
+            FT_STATUS_INC(FT_PRO_NUM_STOP_NONEMPTY_BUF, 1);
             goto relock_and_push_here;
         }
 
@@ -1893,7 +1732,7 @@ static void push_something_in_subtree(
 
         if (next_loc == NEITHER_EXTREME && subtree_root->height <= 1) {
             // Never promote to leaf nodes except on the edges
-            STATUS_INC(FT_PRO_NUM_STOP_H1, 1);
+            FT_STATUS_INC(FT_PRO_NUM_STOP_H1, 1);
             goto relock_and_push_here;
         }
 
@@ -1932,7 +1771,7 @@ static void push_something_in_subtree(
                     r = toku_maybe_pin_ftnode_clean(ft, child_blocknum, child_fullhash, lock_type, &child);
                     if (r != 0) {
                         // We couldn't get the child cheaply, so give up on promoting.
-                        STATUS_INC(FT_PRO_NUM_STOP_LOCK_CHILD, 1);
+                        FT_STATUS_INC(FT_PRO_NUM_STOP_LOCK_CHILD, 1);
                         goto relock_and_push_here;
                     }
                     if (toku_ftnode_fully_in_memory(child)) {
@@ -1943,7 +1782,7 @@ static void push_something_in_subtree(
                         }
                     } else {
                         // We got the child, but it's not fully in memory.  Give up on promoting.
-                        STATUS_INC(FT_PRO_NUM_STOP_CHILD_INMEM, 1);
+                        FT_STATUS_INC(FT_PRO_NUM_STOP_CHILD_INMEM, 1);
                         goto unlock_child_and_push_here;
                     }
                 }
@@ -1974,7 +1813,7 @@ static void push_something_in_subtree(
                 return;
             }
 
-            STATUS_INC(FT_PRO_NUM_DIDNT_WANT_PROMOTE, 1);
+            FT_STATUS_INC(FT_PRO_NUM_DIDNT_WANT_PROMOTE, 1);
         unlock_child_and_push_here:
             // We locked the child, but we decided not to promote.
             // Unlock the child, and fall through to the next case.
@@ -1992,15 +1831,15 @@ static void push_something_in_subtree(
             toku_unpin_ftnode_read_only(ft, subtree_root);
             switch (depth) {
             case 0:
-                STATUS_INC(FT_PRO_NUM_INJECT_DEPTH_0, 1); break;
+                FT_STATUS_INC(FT_PRO_NUM_INJECT_DEPTH_0, 1); break;
             case 1:
-                STATUS_INC(FT_PRO_NUM_INJECT_DEPTH_1, 1); break;
+                FT_STATUS_INC(FT_PRO_NUM_INJECT_DEPTH_1, 1); break;
             case 2:
-                STATUS_INC(FT_PRO_NUM_INJECT_DEPTH_2, 1); break;
+                FT_STATUS_INC(FT_PRO_NUM_INJECT_DEPTH_2, 1); break;
             case 3:
-                STATUS_INC(FT_PRO_NUM_INJECT_DEPTH_3, 1); break;
+                FT_STATUS_INC(FT_PRO_NUM_INJECT_DEPTH_3, 1); break;
             default:
-                STATUS_INC(FT_PRO_NUM_INJECT_DEPTH_GT3, 1); break;
+                FT_STATUS_INC(FT_PRO_NUM_INJECT_DEPTH_GT3, 1); break;
             }
             inject_message_at_this_blocknum(ft, subtree_root_blocknum, subtree_root_fullhash, msg, flow_deltas, gc_info);
         }
@@ -2095,7 +1934,7 @@ void toku_ft_root_put_msg(
             // do the injection.
             toku_unpin_ftnode(ft, node);
             lock_type = PL_READ;
-            STATUS_INC(FT_PRO_NUM_ROOT_SPLIT, 1);
+            FT_STATUS_INC(FT_PRO_NUM_ROOT_SPLIT, 1);
             goto change_lock_type;
         }
         break;
@@ -2112,7 +1951,7 @@ void toku_ft_root_put_msg(
     if (node->height == 0 || !ft_msg_type_applies_once(msg.type())) {
         // If the root's a leaf or we're injecting a broadcast, drop the read lock and inject here.
         toku_unpin_ftnode_read_only(ft, node);
-        STATUS_INC(FT_PRO_NUM_ROOT_H0_INJECT, 1);
+        FT_STATUS_INC(FT_PRO_NUM_ROOT_H0_INJECT, 1);
         inject_message_at_this_blocknum(ft, root_key, fullhash, msg, flow_deltas, gc_info);
     } else if (node->height > 1) {
         // If the root's above height 1, we are definitely eligible for promotion.
@@ -2127,7 +1966,7 @@ void toku_ft_root_put_msg(
         } else {
             // At height 1 in the middle, don't promote, drop the read lock and inject here.
             toku_unpin_ftnode_read_only(ft, node);
-            STATUS_INC(FT_PRO_NUM_ROOT_H1_INJECT, 1);
+            FT_STATUS_INC(FT_PRO_NUM_ROOT_H1_INJECT, 1);
             inject_message_at_this_blocknum(ft, root_key, fullhash, msg, flow_deltas, gc_info);
         }
     }
@@ -2309,7 +2148,7 @@ static int ft_maybe_insert_into_rightmost_leaf(FT ft, DBT *key, DBT *val, XIDS m
     // take care of it. This also ensures that if any of our ancestors are reactive,
     // they'll be taken care of too.
     if (toku_ftnode_get_leaf_reactivity(rightmost_leaf, ft->h->nodesize) != RE_STABLE) {
-        STATUS_INC(FT_PRO_RIGHTMOST_LEAF_SHORTCUT_FAIL_REACTIVE, 1);
+        FT_STATUS_INC(FT_PRO_RIGHTMOST_LEAF_SHORTCUT_FAIL_REACTIVE, 1);
         goto cleanup;
     }
 
@@ -2330,7 +2169,7 @@ static int ft_maybe_insert_into_rightmost_leaf(FT ft, DBT *key, DBT *val, XIDS m
                                                 unique ? &nondeleted_key_found : nullptr,
                                                 &target_childnum);
     if (relative_pos >= 0) {
-        STATUS_INC(FT_PRO_RIGHTMOST_LEAF_SHORTCUT_SUCCESS, 1);
+        FT_STATUS_INC(FT_PRO_RIGHTMOST_LEAF_SHORTCUT_SUCCESS, 1);
         if (unique && nondeleted_key_found) {
             r = DB_KEYEXIST;
         } else {
@@ -2339,7 +2178,7 @@ static int ft_maybe_insert_into_rightmost_leaf(FT ft, DBT *key, DBT *val, XIDS m
             r = 0;
         }
     } else {
-        STATUS_INC(FT_PRO_RIGHTMOST_LEAF_SHORTCUT_FAIL_POS, 1);
+        FT_STATUS_INC(FT_PRO_RIGHTMOST_LEAF_SHORTCUT_FAIL_POS, 1);
         r = -1;
     }
 
@@ -2932,7 +2771,7 @@ void toku_ft_change_descriptor(
     new_d.dbt = *new_descriptor;
     toku_ft_update_descriptor(ft_h->ft, &new_d);
     // very infrequent operation, worth precise threadsafe count
-    STATUS_INC(FT_DESCRIPTOR_SET, 1);
+    FT_STATUS_INC(FT_DESCRIPTOR_SET, 1);
 
     if (update_cmp_descriptor) {
         toku_ft_update_cmp_descriptor(ft_h->ft);
@@ -3384,7 +3223,7 @@ ok: ;
             case FT_SEARCH_LEFT:
                 idx++;
                 if (idx >= bn->data_buffer.num_klpairs() || ((n_deleted % 64) == 0 && !search_continue(search, key, keylen))) {
-                    STATUS_INC(FT_CURSOR_SKIP_DELETED_LEAF_ENTRY, n_deleted);
+                    FT_STATUS_INC(FT_CURSOR_SKIP_DELETED_LEAF_ENTRY, n_deleted);
                     if (ftcursor->interrupt_cb && ftcursor->interrupt_cb(ftcursor->interrupt_cb_extra, n_deleted)) {
                         return TOKUDB_INTERRUPTED;
                     }
@@ -3393,7 +3232,7 @@ ok: ;
                 break;
             case FT_SEARCH_RIGHT:
                 if (idx == 0) {
-                    STATUS_INC(FT_CURSOR_SKIP_DELETED_LEAF_ENTRY, n_deleted);
+                    FT_STATUS_INC(FT_CURSOR_SKIP_DELETED_LEAF_ENTRY, n_deleted);
                     if (ftcursor->interrupt_cb && ftcursor->interrupt_cb(ftcursor->interrupt_cb_extra, n_deleted)) {
                         return TOKUDB_INTERRUPTED;
                     }
@@ -3407,7 +3246,7 @@ ok: ;
             r = bn->data_buffer.fetch_klpair(idx, &le, &keylen, &key);
             assert_zero(r); // we just validated the index
             if (!le_val_is_del(le, ftcursor->read_type, ftcursor->ttxn)) {
-                STATUS_INC(FT_CURSOR_SKIP_DELETED_LEAF_ENTRY, n_deleted);
+                FT_STATUS_INC(FT_CURSOR_SKIP_DELETED_LEAF_ENTRY, n_deleted);
                 if (ftcursor->interrupt_cb)
                     ftcursor->interrupt_cb(ftcursor->interrupt_cb_extra, n_deleted);
                 goto got_a_good_value;
@@ -3946,12 +3785,12 @@ try_again:
     {   // accounting (to detect and measure thrashing)
         uint retrycount = trycount - 1;         // how many retries were needed?
         if (retrycount) {
-            STATUS_INC(FT_TOTAL_RETRIES, retrycount);
+            FT_STATUS_INC(FT_TOTAL_RETRIES, retrycount);
         }
         if (retrycount > tree_height) {         // if at least one node was read from disk more than once
-            STATUS_INC(FT_SEARCH_TRIES_GT_HEIGHT, 1);
+            FT_STATUS_INC(FT_SEARCH_TRIES_GT_HEIGHT, 1);
             if (retrycount > (tree_height+3))
-                STATUS_INC(FT_SEARCH_TRIES_GT_HEIGHTPLUS3, 1);
+                FT_STATUS_INC(FT_SEARCH_TRIES_GT_HEIGHTPLUS3, 1);
         }
     }
     return r;
@@ -4536,9 +4375,7 @@ int toku_ft_layer_init(void) {
     if (r) { goto exit; }
 
     partitioned_counters_init();
-    status_init();
-    txn_status_init();
-    toku_ule_status_init();
+    toku_status_init();
     toku_checkpoint_init();
     toku_ft_serialize_layer_init();
     toku_mutex_init(&ft_open_close_lock, NULL);
@@ -4551,10 +4388,8 @@ void toku_ft_layer_destroy(void) {
     toku_mutex_destroy(&ft_open_close_lock);
     toku_ft_serialize_layer_destroy();
     toku_checkpoint_destroy();
-    status_destroy();
-    txn_status_destroy();
-    toku_ule_status_destroy();
     toku_context_status_destroy();
+    toku_status_destroy();
     partitioned_counters_destroy();
     toku_scoped_malloc_destroy();
     //Portability must be cleaned up last
@@ -4742,5 +4577,3 @@ void
 toku_ft_helgrind_ignore(void) {
     TOKU_VALGRIND_HG_DISABLE_CHECKING(&ft_status, sizeof ft_status);
 }
-
-#undef STATUS_INC

--- a/ft/ft-status.cc
+++ b/ft/ft-status.cc
@@ -1,0 +1,523 @@
+/* -*- mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+// vim: ft=cpp:expandtab:ts=8:sw=4:softtabstop=4:
+#ident "$Id$"
+/*
+COPYING CONDITIONS NOTICE:
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of version 2 of the GNU General Public License as
+  published by the Free Software Foundation, and provided that the
+  following conditions are met:
+
+      * Redistributions of source code must retain this COPYING
+        CONDITIONS NOTICE, the COPYRIGHT NOTICE (below), the
+        DISCLAIMER (below), the UNIVERSITY PATENT NOTICE (below), the
+        PATENT MARKING NOTICE (below), and the PATENT RIGHTS
+        GRANT (below).
+
+      * Redistributions in binary form must reproduce this COPYING
+        CONDITIONS NOTICE, the COPYRIGHT NOTICE (below), the
+        DISCLAIMER (below), the UNIVERSITY PATENT NOTICE (below), the
+        PATENT MARKING NOTICE (below), and the PATENT RIGHTS
+        GRANT (below) in the documentation and/or other materials
+        provided with the distribution.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+  02110-1301, USA.
+
+COPYRIGHT NOTICE:
+
+  TokuFT, Tokutek Fractal Tree Indexing Library.
+  Copyright (C) 2007-2013 Tokutek, Inc.
+
+DISCLAIMER:
+
+  This program is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  General Public License for more details.
+
+UNIVERSITY PATENT NOTICE:
+
+  The technology is licensed by the Massachusetts Institute of
+  Technology, Rutgers State University of New Jersey, and the Research
+  Foundation of State University of New York at Stony Brook under
+  United States of America Serial No. 11/760379 and to the patents
+  and/or patent applications resulting from it.
+
+PATENT MARKING NOTICE:
+
+  This software is covered by US Patent No. 8,185,551.
+  This software is covered by US Patent No. 8,489,638.
+
+PATENT RIGHTS GRANT:
+
+  "THIS IMPLEMENTATION" means the copyrightable works distributed by
+  Tokutek as part of the Fractal Tree project.
+
+  "PATENT CLAIMS" means the claims of patents that are owned or
+  licensable by Tokutek, both currently or in the future; and that in
+  the absence of this license would be infringed by THIS
+  IMPLEMENTATION or by using or running THIS IMPLEMENTATION.
+
+  "PATENT CHALLENGE" shall mean a challenge to the validity,
+  patentability, enforceability and/or non-infringement of any of the
+  PATENT CLAIMS or otherwise opposing any of the PATENT CLAIMS.
+
+  Tokutek hereby grants to you, for the term and geographical scope of
+  the PATENT CLAIMS, a non-exclusive, no-charge, royalty-free,
+  irrevocable (except as stated in this section) patent license to
+  make, have made, use, offer to sell, sell, import, transfer, and
+  otherwise run, modify, and propagate the contents of THIS
+  IMPLEMENTATION, where such license applies only to the PATENT
+  CLAIMS.  This grant does not include claims that would be infringed
+  only as a consequence of further modifications of THIS
+  IMPLEMENTATION.  If you or your agent or licensee institute or order
+  or agree to the institution of patent litigation against any entity
+  (including a cross-claim or counterclaim in a lawsuit) alleging that
+  THIS IMPLEMENTATION constitutes direct or contributory patent
+  infringement, or inducement of patent infringement, then any rights
+  granted to you under this License shall terminate as of the date
+  such litigation is filed.  If you or your agent or exclusive
+  licensee institute or order or agree to the institution of a PATENT
+  CHALLENGE, then Tokutek may terminate any rights granted to you
+  under this License.
+*/
+
+#ident "Copyright (c) 2007-2013 Tokutek Inc.  All rights reserved."
+#ident "The technology is licensed by the Massachusetts Institute of Technology, Rutgers State University of New Jersey, and the Research Foundation of State University of New York at Stony Brook under United States of America Serial No. 11/760379 and to the patents and/or patent applications resulting from it."
+
+#include "ft/ft.h"
+#include "ft/ft-status.h"
+
+#include <toku_race_tools.h>
+
+LE_STATUS_S le_status;
+void LE_STATUS_S::init() {
+    if (m_initialized) return;
+#define LE_STATUS_INIT(k,c,t,l,inc) TOKUFT_STATUS_INIT((*this), k, c, t, "le: " l, inc)
+    LE_STATUS_INIT(LE_MAX_COMMITTED_XR,   nullptr, UINT64, "max committed xr", TOKU_ENGINE_STATUS);
+    LE_STATUS_INIT(LE_MAX_PROVISIONAL_XR, nullptr, UINT64, "max provisional xr", TOKU_ENGINE_STATUS);
+    LE_STATUS_INIT(LE_EXPANDED,           nullptr, UINT64, "expanded", TOKU_ENGINE_STATUS);
+    LE_STATUS_INIT(LE_MAX_MEMSIZE,        nullptr, UINT64, "max memsize", TOKU_ENGINE_STATUS);
+    LE_STATUS_INIT(LE_APPLY_GC_BYTES_IN,  nullptr, PARCOUNT, "size of leafentries before garbage collection (during message application)", TOKU_ENGINE_STATUS);
+    LE_STATUS_INIT(LE_APPLY_GC_BYTES_OUT, nullptr, PARCOUNT, "size of leafentries after garbage collection (during message application)", TOKU_ENGINE_STATUS);
+    LE_STATUS_INIT(LE_NORMAL_GC_BYTES_IN, nullptr, PARCOUNT, "size of leafentries before garbage collection (outside message application)", TOKU_ENGINE_STATUS);
+    LE_STATUS_INIT(LE_NORMAL_GC_BYTES_OUT,nullptr, PARCOUNT, "size of leafentries after garbage collection (outside message application)", TOKU_ENGINE_STATUS);
+    m_initialized = true;
+#undef LE_STATUS_INIT
+}
+void LE_STATUS_S::destroy() {
+    if (!m_initialized) return;
+    for (int i = 0; i < LE_STATUS_NUM_ROWS; ++i) {
+        if (status[i].type == PARCOUNT) {
+            destroy_partitioned_counter(status[i].value.parcount);
+        }
+    }
+}
+
+
+
+CHECKPOINT_STATUS_S cp_status;
+void CHECKPOINT_STATUS_S::init(void) {
+    if (m_initialized) return;
+#define CP_STATUS_INIT(k,c,t,l,inc) TOKUFT_STATUS_INIT((*this), k, c, t, "checkpoint: " l, inc)
+    CP_STATUS_INIT(CP_PERIOD,                              CHECKPOINT_PERIOD, UINT64,   "period", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    CP_STATUS_INIT(CP_FOOTPRINT,                           nullptr, UINT64,   "footprint", TOKU_ENGINE_STATUS);
+    CP_STATUS_INIT(CP_TIME_LAST_CHECKPOINT_BEGIN,          CHECKPOINT_LAST_BEGAN, UNIXTIME, "last checkpoint began ", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    CP_STATUS_INIT(CP_TIME_LAST_CHECKPOINT_BEGIN_COMPLETE, CHECKPOINT_LAST_COMPLETE_BEGAN, UNIXTIME, "last complete checkpoint began ", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    CP_STATUS_INIT(CP_TIME_LAST_CHECKPOINT_END,            CHECKPOINT_LAST_COMPLETE_ENDED, UNIXTIME, "last complete checkpoint ended", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    CP_STATUS_INIT(CP_TIME_CHECKPOINT_DURATION,            CHECKPOINT_DURATION, UINT64, "time spent during checkpoint (begin and end phases)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    CP_STATUS_INIT(CP_TIME_CHECKPOINT_DURATION_LAST,       CHECKPOINT_DURATION_LAST, UINT64, "time spent during last checkpoint (begin and end phases)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    CP_STATUS_INIT(CP_LAST_LSN,                            nullptr, UINT64,   "last complete checkpoint LSN", TOKU_ENGINE_STATUS);
+    CP_STATUS_INIT(CP_CHECKPOINT_COUNT,                    CHECKPOINT_TAKEN, UINT64,   "checkpoints taken ", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    CP_STATUS_INIT(CP_CHECKPOINT_COUNT_FAIL,               CHECKPOINT_FAILED, UINT64,   "checkpoints failed", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    CP_STATUS_INIT(CP_WAITERS_NOW,                         nullptr, UINT64,   "waiters now", TOKU_ENGINE_STATUS);
+    CP_STATUS_INIT(CP_WAITERS_MAX,                         nullptr, UINT64,   "waiters max", TOKU_ENGINE_STATUS);
+    CP_STATUS_INIT(CP_CLIENT_WAIT_ON_MO,                   nullptr, UINT64,   "non-checkpoint client wait on mo lock", TOKU_ENGINE_STATUS);
+    CP_STATUS_INIT(CP_CLIENT_WAIT_ON_CS,                   nullptr, UINT64,   "non-checkpoint client wait on cs lock", TOKU_ENGINE_STATUS);
+
+    CP_STATUS_INIT(CP_BEGIN_TIME,                          CHECKPOINT_BEGIN_TIME, UINT64,   "checkpoint begin time", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    CP_STATUS_INIT(CP_LONG_BEGIN_COUNT,                    CHECKPOINT_LONG_BEGIN_COUNT, UINT64,   "long checkpoint begin count", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    CP_STATUS_INIT(CP_LONG_BEGIN_TIME,                     CHECKPOINT_LONG_BEGIN_TIME, UINT64,   "long checkpoint begin time", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+
+    m_initialized = true;
+#undef CP_STATUS_INIT
+}
+void CHECKPOINT_STATUS_S::destroy() {
+    if (!m_initialized) return;
+    for (int i = 0; i < CP_STATUS_NUM_ROWS; ++i) {
+        if (status[i].type == PARCOUNT) {
+            destroy_partitioned_counter(status[i].value.parcount);
+        }
+    }
+}
+
+CACHETABLE_STATUS_S ct_status;
+void CACHETABLE_STATUS_S::init() {
+    if (m_initialized) return;
+#define CT_STATUS_INIT(k,c,t,l,inc) TOKUFT_STATUS_INIT((*this), k, c, t, "cachetable: " l, inc)
+    CT_STATUS_INIT(CT_MISS,                   CACHETABLE_MISS, UINT64, "miss", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    CT_STATUS_INIT(CT_MISSTIME,               CACHETABLE_MISS_TIME, UINT64, "miss time", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    CT_STATUS_INIT(CT_PREFETCHES,             CACHETABLE_PREFETCHES, UINT64, "prefetches", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    CT_STATUS_INIT(CT_SIZE_CURRENT,           CACHETABLE_SIZE_CURRENT, UINT64, "size current", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    CT_STATUS_INIT(CT_SIZE_LIMIT,             CACHETABLE_SIZE_LIMIT, UINT64, "size limit", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    CT_STATUS_INIT(CT_SIZE_WRITING,           CACHETABLE_SIZE_WRITING, UINT64, "size writing", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    CT_STATUS_INIT(CT_SIZE_NONLEAF,           CACHETABLE_SIZE_NONLEAF, UINT64, "size nonleaf", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    CT_STATUS_INIT(CT_SIZE_LEAF,              CACHETABLE_SIZE_LEAF, UINT64, "size leaf", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    CT_STATUS_INIT(CT_SIZE_ROLLBACK,          CACHETABLE_SIZE_ROLLBACK, UINT64, "size rollback", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    CT_STATUS_INIT(CT_SIZE_CACHEPRESSURE,     CACHETABLE_SIZE_CACHEPRESSURE, UINT64, "size cachepressure", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    CT_STATUS_INIT(CT_SIZE_CLONED,            CACHETABLE_SIZE_CLONED, UINT64, "size currently cloned data for checkpoint", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    CT_STATUS_INIT(CT_EVICTIONS,              CACHETABLE_EVICTIONS, UINT64, "evictions", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    CT_STATUS_INIT(CT_CLEANER_EXECUTIONS,     CACHETABLE_CLEANER_EXECUTIONS, UINT64, "cleaner executions", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    CT_STATUS_INIT(CT_CLEANER_PERIOD,         CACHETABLE_CLEANER_PERIOD, UINT64, "cleaner period", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    CT_STATUS_INIT(CT_CLEANER_ITERATIONS,     CACHETABLE_CLEANER_ITERATIONS, UINT64, "cleaner iterations", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    
+    CT_STATUS_INIT(CT_WAIT_PRESSURE_COUNT,    CACHETABLE_WAIT_PRESSURE_COUNT, UINT64, "number of waits on cache pressure", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    CT_STATUS_INIT(CT_WAIT_PRESSURE_TIME,    CACHETABLE_WAIT_PRESSURE_TIME, UINT64, "time waiting on cache pressure", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    CT_STATUS_INIT(CT_LONG_WAIT_PRESSURE_COUNT,    CACHETABLE_LONG_WAIT_PRESSURE_COUNT, UINT64, "number of long waits on cache pressure", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    CT_STATUS_INIT(CT_LONG_WAIT_PRESSURE_TIME,    CACHETABLE_LONG_WAIT_PRESSURE_TIME, UINT64, "long time waiting on cache pressure", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    m_initialized = true;
+
+#undef CT_STATUS_INIT
+}
+void CACHETABLE_STATUS_S::destroy() {
+    if (!m_initialized) return;
+    for (int i = 0; i < CT_STATUS_NUM_ROWS; ++i) {
+        if (status[i].type == PARCOUNT) {
+            destroy_partitioned_counter(status[i].value.parcount);
+        }
+    }
+}
+
+
+
+LTM_STATUS_S ltm_status;
+void LTM_STATUS_S::init() {
+    if (m_initialized) return;
+#define LTM_STATUS_INIT(k,c,t,l,inc) TOKUFT_STATUS_INIT((*this), k, c, t, "locktree: " l, inc)
+    LTM_STATUS_INIT(LTM_SIZE_CURRENT,             LOCKTREE_MEMORY_SIZE, UINT64,   "memory size", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    LTM_STATUS_INIT(LTM_SIZE_LIMIT,               LOCKTREE_MEMORY_SIZE_LIMIT, UINT64,   "memory size limit", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    LTM_STATUS_INIT(LTM_ESCALATION_COUNT,         LOCKTREE_ESCALATION_NUM, UINT64, "number of times lock escalation ran", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    LTM_STATUS_INIT(LTM_ESCALATION_TIME,          LOCKTREE_ESCALATION_SECONDS, TOKUTIME, "time spent running escalation (seconds)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    LTM_STATUS_INIT(LTM_ESCALATION_LATEST_RESULT, LOCKTREE_LATEST_POST_ESCALATION_MEMORY_SIZE, UINT64,   "latest post-escalation memory size", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    LTM_STATUS_INIT(LTM_NUM_LOCKTREES,            LOCKTREE_OPEN_CURRENT, UINT64,   "number of locktrees open now", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    LTM_STATUS_INIT(LTM_LOCK_REQUESTS_PENDING,    LOCKTREE_PENDING_LOCK_REQUESTS, UINT64,   "number of pending lock requests", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    LTM_STATUS_INIT(LTM_STO_NUM_ELIGIBLE,         LOCKTREE_STO_ELIGIBLE_NUM, UINT64,   "number of locktrees eligible for the STO", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    LTM_STATUS_INIT(LTM_STO_END_EARLY_COUNT,      LOCKTREE_STO_ENDED_NUM, UINT64,   "number of times a locktree ended the STO early", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    LTM_STATUS_INIT(LTM_STO_END_EARLY_TIME,       LOCKTREE_STO_ENDED_SECONDS, TOKUTIME, "time spent ending the STO early (seconds)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+
+    LTM_STATUS_INIT(LTM_WAIT_COUNT,               LOCKTREE_WAIT_COUNT, UINT64, "number of wait locks", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    LTM_STATUS_INIT(LTM_WAIT_TIME,                LOCKTREE_WAIT_TIME, UINT64, "time waiting for locks", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    LTM_STATUS_INIT(LTM_LONG_WAIT_COUNT,          LOCKTREE_LONG_WAIT_COUNT, UINT64, "number of long wait locks", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    LTM_STATUS_INIT(LTM_LONG_WAIT_TIME,           LOCKTREE_LONG_WAIT_TIME, UINT64, "long time waiting for locks", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    LTM_STATUS_INIT(LTM_TIMEOUT_COUNT,            LOCKTREE_TIMEOUT_COUNT, UINT64, "number of lock timeouts", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+
+    LTM_STATUS_INIT(LTM_WAIT_ESCALATION_COUNT,    LOCKTREE_WAIT_ESCALATION_COUNT, UINT64, "number of waits on lock escalation", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    LTM_STATUS_INIT(LTM_WAIT_ESCALATION_TIME,     LOCKTREE_WAIT_ESCALATION_TIME, UINT64, "time waiting on lock escalation", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    LTM_STATUS_INIT(LTM_LONG_WAIT_ESCALATION_COUNT,    LOCKTREE_LONG_WAIT_ESCALATION_COUNT, UINT64, "number of long waits on lock escalation", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    LTM_STATUS_INIT(LTM_LONG_WAIT_ESCALATION_TIME,     LOCKTREE_LONG_WAIT_ESCALATION_TIME, UINT64, "long time waiting on lock escalation", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+
+    m_initialized = true;
+#undef LTM_STATUS_INIT
+}
+void LTM_STATUS_S::destroy() {
+    if (!m_initialized) return;
+    for (int i = 0; i < LTM_STATUS_NUM_ROWS; ++i) {
+        if (status[i].type == PARCOUNT) {
+            destroy_partitioned_counter(status[i].value.parcount);
+        }
+    }
+}
+
+
+
+FT_STATUS_S ft_status;
+void FT_STATUS_S::init() {
+    if (m_initialized) return;
+#define FT_STATUS_INIT(k,c,t,l,inc) TOKUFT_STATUS_INIT((*this), k, c, t, "ft: " l, inc)
+    FT_STATUS_INIT(FT_UPDATES,                                DICTIONARY_UPDATES, PARCOUNT, "dictionary updates", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_UPDATES_BROADCAST,                      DICTIONARY_BROADCAST_UPDATES, PARCOUNT, "dictionary broadcast updates", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_DESCRIPTOR_SET,                         DESCRIPTOR_SET, PARCOUNT, "descriptor set", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_MSN_DISCARDS,                           MESSAGES_IGNORED_BY_LEAF_DUE_TO_MSN, PARCOUNT, "messages ignored by leaf due to msn", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_TOTAL_RETRIES,                          nullptr, PARCOUNT, "total search retries due to TRY_AGAIN", TOKU_ENGINE_STATUS);
+    FT_STATUS_INIT(FT_SEARCH_TRIES_GT_HEIGHT,                 nullptr, PARCOUNT, "searches requiring more tries than the height of the tree", TOKU_ENGINE_STATUS);
+    FT_STATUS_INIT(FT_SEARCH_TRIES_GT_HEIGHTPLUS3,            nullptr, PARCOUNT, "searches requiring more tries than the height of the tree plus three", TOKU_ENGINE_STATUS);
+    FT_STATUS_INIT(FT_CREATE_LEAF,                            LEAF_NODES_CREATED, PARCOUNT, "leaf nodes created", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_CREATE_NONLEAF,                         NONLEAF_NODES_CREATED, PARCOUNT, "nonleaf nodes created", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_DESTROY_LEAF,                           LEAF_NODES_DESTROYED, PARCOUNT, "leaf nodes destroyed", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_DESTROY_NONLEAF,                        NONLEAF_NODES_DESTROYED, PARCOUNT, "nonleaf nodes destroyed", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_MSG_BYTES_IN,                           MESSAGES_INJECTED_AT_ROOT_BYTES, PARCOUNT, "bytes of messages injected at root (all trees)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_MSG_BYTES_OUT,                          MESSAGES_FLUSHED_FROM_H1_TO_LEAVES_BYTES, PARCOUNT, "bytes of messages flushed from h1 nodes to leaves", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_MSG_BYTES_CURR,                         MESSAGES_IN_TREES_ESTIMATE_BYTES, PARCOUNT, "bytes of messages currently in trees (estimate)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_MSG_NUM,                                MESSAGES_INJECTED_AT_ROOT, PARCOUNT, "messages injected at root", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_MSG_NUM_BROADCAST,                      BROADCASE_MESSAGES_INJECTED_AT_ROOT, PARCOUNT, "broadcast messages injected at root", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+
+    FT_STATUS_INIT(FT_NUM_BASEMENTS_DECOMPRESSED_NORMAL,      BASEMENTS_DECOMPRESSED_TARGET_QUERY, PARCOUNT, "basements decompressed as a target of a query", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_NUM_BASEMENTS_DECOMPRESSED_AGGRESSIVE,  BASEMENTS_DECOMPRESSED_PRELOCKED_RANGE, PARCOUNT, "basements decompressed for prelocked range", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_NUM_BASEMENTS_DECOMPRESSED_PREFETCH,    BASEMENTS_DECOMPRESSED_PREFETCH, PARCOUNT, "basements decompressed for prefetch", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_NUM_BASEMENTS_DECOMPRESSED_WRITE,       BASEMENTS_DECOMPRESSED_FOR_WRITE, PARCOUNT, "basements decompressed for write", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_NUM_MSG_BUFFER_DECOMPRESSED_NORMAL,     BUFFERS_DECOMPRESSED_TARGET_QUERY, PARCOUNT, "buffers decompressed as a target of a query", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_NUM_MSG_BUFFER_DECOMPRESSED_AGGRESSIVE, BUFFERS_DECOMPRESSED_PRELOCKED_RANGE, PARCOUNT, "buffers decompressed for prelocked range", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_NUM_MSG_BUFFER_DECOMPRESSED_PREFETCH,   BUFFERS_DECOMPRESSED_PREFETCH, PARCOUNT, "buffers decompressed for prefetch", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_NUM_MSG_BUFFER_DECOMPRESSED_WRITE,      BUFFERS_DECOMPRESSED_FOR_WRITE, PARCOUNT, "buffers decompressed for write", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+
+    // Eviction statistics:
+    FT_STATUS_INIT(FT_FULL_EVICTIONS_LEAF,                    LEAF_NODE_FULL_EVICTIONS, PARCOUNT, "leaf node full evictions", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_FULL_EVICTIONS_LEAF_BYTES,              LEAF_NODE_FULL_EVICTIONS_BYTES, PARCOUNT, "leaf node full evictions (bytes)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_FULL_EVICTIONS_NONLEAF,                 NONLEAF_NODE_FULL_EVICTIONS, PARCOUNT, "nonleaf node full evictions", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_FULL_EVICTIONS_NONLEAF_BYTES,           NONLEAF_NODE_FULL_EVICTIONS_BYTES, PARCOUNT, "nonleaf node full evictions (bytes)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_PARTIAL_EVICTIONS_LEAF,                 LEAF_NODE_PARTIAL_EVICTIONS, PARCOUNT, "leaf node partial evictions", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_PARTIAL_EVICTIONS_LEAF_BYTES,           LEAF_NODE_PARTIAL_EVICTIONS_BYTES, PARCOUNT, "leaf node partial evictions (bytes)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_PARTIAL_EVICTIONS_NONLEAF,              NONLEAF_NODE_PARTIAL_EVICTIONS, PARCOUNT, "nonleaf node partial evictions", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_PARTIAL_EVICTIONS_NONLEAF_BYTES,        NONLEAF_NODE_PARTIAL_EVICTIONS_BYTES, PARCOUNT, "nonleaf node partial evictions (bytes)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+
+    // Disk read statistics: 
+    //
+    // Pivots: For queries, prefetching, or writing.
+    FT_STATUS_INIT(FT_NUM_PIVOTS_FETCHED_QUERY,               PIVOTS_FETCHED_FOR_QUERY, PARCOUNT, "pivots fetched for query", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_BYTES_PIVOTS_FETCHED_QUERY,             PIVOTS_FETCHED_FOR_QUERY_BYTES, PARCOUNT, "pivots fetched for query (bytes)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_TOKUTIME_PIVOTS_FETCHED_QUERY,          PIVOTS_FETCHED_FOR_QUERY_SECONDS, TOKUTIME, "pivots fetched for query (seconds)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_NUM_PIVOTS_FETCHED_PREFETCH,            PIVOTS_FETCHED_FOR_PREFETCH, PARCOUNT, "pivots fetched for prefetch", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_BYTES_PIVOTS_FETCHED_PREFETCH,          PIVOTS_FETCHED_FOR_PREFETCH_BYTES, PARCOUNT, "pivots fetched for prefetch (bytes)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_TOKUTIME_PIVOTS_FETCHED_PREFETCH,       PIVOTS_FETCHED_FOR_PREFETCH_SECONDS, TOKUTIME, "pivots fetched for prefetch (seconds)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_NUM_PIVOTS_FETCHED_WRITE,               PIVOTS_FETCHED_FOR_WRITE, PARCOUNT, "pivots fetched for write", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_BYTES_PIVOTS_FETCHED_WRITE,             PIVOTS_FETCHED_FOR_WRITE_BYTES, PARCOUNT, "pivots fetched for write (bytes)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_TOKUTIME_PIVOTS_FETCHED_WRITE,          PIVOTS_FETCHED_FOR_WRITE_SECONDS, TOKUTIME, "pivots fetched for write (seconds)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    // Basements: For queries, aggressive fetching in prelocked range, prefetching, or writing.
+    FT_STATUS_INIT(FT_NUM_BASEMENTS_FETCHED_NORMAL,           BASEMENTS_FETCHED_TARGET_QUERY, PARCOUNT, "basements fetched as a target of a query", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_BYTES_BASEMENTS_FETCHED_NORMAL,         BASEMENTS_FETCHED_TARGET_QUERY_BYTES, PARCOUNT, "basements fetched as a target of a query (bytes)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_TOKUTIME_BASEMENTS_FETCHED_NORMAL,      BASEMENTS_FETCHED_TARGET_QUERY_SECONDS, TOKUTIME, "basements fetched as a target of a query (seconds)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_NUM_BASEMENTS_FETCHED_AGGRESSIVE,       BASEMENTS_FETCHED_PRELOCKED_RANGE, PARCOUNT, "basements fetched for prelocked range", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_BYTES_BASEMENTS_FETCHED_AGGRESSIVE,     BASEMENTS_FETCHED_PRELOCKED_RANGE_BYTES, PARCOUNT, "basements fetched for prelocked range (bytes)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_TOKUTIME_BASEMENTS_FETCHED_AGGRESSIVE,  BASEMENTS_FETCHED_PRELOCKED_RANGE_SECONDS, TOKUTIME, "basements fetched for prelocked range (seconds)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_NUM_BASEMENTS_FETCHED_PREFETCH,         BASEMENTS_FETCHED_PREFETCH, PARCOUNT, "basements fetched for prefetch", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_BYTES_BASEMENTS_FETCHED_PREFETCH,       BASEMENTS_FETCHED_PREFETCH_BYTES, PARCOUNT, "basements fetched for prefetch (bytes)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_TOKUTIME_BASEMENTS_FETCHED_PREFETCH,    BASEMENTS_FETCHED_PREFETCH_SECONDS, TOKUTIME, "basements fetched for prefetch (seconds)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_NUM_BASEMENTS_FETCHED_WRITE,            BASEMENTS_FETCHED_FOR_WRITE, PARCOUNT, "basements fetched for write", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_BYTES_BASEMENTS_FETCHED_WRITE,          BASEMENTS_FETCHED_FOR_WRITE_BYTES, PARCOUNT, "basements fetched for write (bytes)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_TOKUTIME_BASEMENTS_FETCHED_WRITE,       BASEMENTS_FETCHED_FOR_WRITE_SECONDS, TOKUTIME, "basements fetched for write (seconds)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    // Buffers: For queries, aggressive fetching in prelocked range, prefetching, or writing.
+    FT_STATUS_INIT(FT_NUM_MSG_BUFFER_FETCHED_NORMAL,          BUFFERS_FETCHED_TARGET_QUERY, PARCOUNT, "buffers fetched as a target of a query", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_BYTES_MSG_BUFFER_FETCHED_NORMAL,        BUFFERS_FETCHED_TARGET_QUERY_BYTES, PARCOUNT, "buffers fetched as a target of a query (bytes)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_TOKUTIME_MSG_BUFFER_FETCHED_NORMAL,     BUFFERS_FETCHED_TARGET_QUERY_SECONDS, TOKUTIME, "buffers fetched as a target of a query (seconds)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_NUM_MSG_BUFFER_FETCHED_AGGRESSIVE,      BUFFERS_FETCHED_PRELOCKED_RANGE, PARCOUNT, "buffers fetched for prelocked range", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_BYTES_MSG_BUFFER_FETCHED_AGGRESSIVE,    BUFFERS_FETCHED_PRELOCKED_RANGE_BYTES, PARCOUNT, "buffers fetched for prelocked range (bytes)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_TOKUTIME_MSG_BUFFER_FETCHED_AGGRESSIVE, BUFFERS_FETCHED_PRELOCKED_RANGE_SECONDS, TOKUTIME, "buffers fetched for prelocked range (seconds)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_NUM_MSG_BUFFER_FETCHED_PREFETCH,        BUFFERS_FETCHED_PREFETCH, PARCOUNT, "buffers fetched for prefetch", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_BYTES_MSG_BUFFER_FETCHED_PREFETCH,      BUFFERS_FETCHED_PREFETCH_BYTES, PARCOUNT, "buffers fetched for prefetch (bytes)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_TOKUTIME_MSG_BUFFER_FETCHED_PREFETCH,   BUFFERS_FETCHED_PREFETCH_SECONDS, TOKUTIME, "buffers fetched for prefetch (seconds)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_NUM_MSG_BUFFER_FETCHED_WRITE,           BUFFERS_FETCHED_FOR_WRITE, PARCOUNT, "buffers fetched for write", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_BYTES_MSG_BUFFER_FETCHED_WRITE,         BUFFERS_FETCHED_FOR_WRITE_BYTES, PARCOUNT, "buffers fetched for write (bytes)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_TOKUTIME_MSG_BUFFER_FETCHED_WRITE,      BUFFERS_FETCHED_FOR_WRITE_SECONDS, TOKUTIME, "buffers fetched for write (seconds)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+
+    // Disk write statistics.
+    //
+    // Leaf/Nonleaf: Not for checkpoint
+    FT_STATUS_INIT(FT_DISK_FLUSH_LEAF,                                         LEAF_NODES_FLUSHED_NOT_CHECKPOINT, PARCOUNT, "leaf nodes flushed to disk (not for checkpoint)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_DISK_FLUSH_LEAF_BYTES,                                   LEAF_NODES_FLUSHED_NOT_CHECKPOINT_BYTES, PARCOUNT, "leaf nodes flushed to disk (not for checkpoint) (bytes)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_DISK_FLUSH_LEAF_UNCOMPRESSED_BYTES,                      LEAF_NODES_FLUSHED_NOT_CHECKPOINT_UNCOMPRESSED_BYTES, PARCOUNT, "leaf nodes flushed to disk (not for checkpoint) (uncompressed bytes)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_DISK_FLUSH_LEAF_TOKUTIME,                                LEAF_NODES_FLUSHED_NOT_CHECKPOINT_SECONDS, TOKUTIME, "leaf nodes flushed to disk (not for checkpoint) (seconds)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_DISK_FLUSH_NONLEAF,                                      NONLEAF_NODES_FLUSHED_TO_DISK_NOT_CHECKPOINT, PARCOUNT, "nonleaf nodes flushed to disk (not for checkpoint)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_DISK_FLUSH_NONLEAF_BYTES,                                NONLEAF_NODES_FLUSHED_TO_DISK_NOT_CHECKPOINT_BYTES, PARCOUNT, "nonleaf nodes flushed to disk (not for checkpoint) (bytes)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_DISK_FLUSH_NONLEAF_UNCOMPRESSED_BYTES,                   NONLEAF_NODES_FLUSHED_TO_DISK_NOT_CHECKPOINT_UNCOMPRESSED_BYTES, PARCOUNT, "nonleaf nodes flushed to disk (not for checkpoint) (uncompressed bytes)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_DISK_FLUSH_NONLEAF_TOKUTIME,                             NONLEAF_NODES_FLUSHED_TO_DISK_NOT_CHECKPOINT_SECONDS, TOKUTIME, "nonleaf nodes flushed to disk (not for checkpoint) (seconds)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    // Leaf/Nonleaf: For checkpoint
+    FT_STATUS_INIT(FT_DISK_FLUSH_LEAF_FOR_CHECKPOINT,                          LEAF_NODES_FLUSHED_CHECKPOINT, PARCOUNT, "leaf nodes flushed to disk (for checkpoint)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_DISK_FLUSH_LEAF_BYTES_FOR_CHECKPOINT,                    LEAF_NODES_FLUSHED_CHECKPOINT_BYTES, PARCOUNT, "leaf nodes flushed to disk (for checkpoint) (bytes)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_DISK_FLUSH_LEAF_UNCOMPRESSED_BYTES_FOR_CHECKPOINT,       LEAF_NODES_FLUSHED_CHECKPOINT_UNCOMPRESSED_BYTES, PARCOUNT, "leaf nodes flushed to disk (for checkpoint) (uncompressed bytes)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_DISK_FLUSH_LEAF_TOKUTIME_FOR_CHECKPOINT,                 LEAF_NODES_FLUSHED_CHECKPOINT_SECONDS, TOKUTIME, "leaf nodes flushed to disk (for checkpoint) (seconds)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_DISK_FLUSH_NONLEAF_FOR_CHECKPOINT,                       NONLEAF_NODES_FLUSHED_TO_DISK_CHECKPOINT, PARCOUNT, "nonleaf nodes flushed to disk (for checkpoint)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_DISK_FLUSH_NONLEAF_BYTES_FOR_CHECKPOINT,                 NONLEAF_NODES_FLUSHED_TO_DISK_CHECKPOINT_BYTES, PARCOUNT, "nonleaf nodes flushed to disk (for checkpoint) (bytes)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_DISK_FLUSH_NONLEAF_UNCOMPRESSED_BYTES_FOR_CHECKPOINT,    NONLEAF_NODES_FLUSHED_TO_DISK_CHECKPOINT_UNCOMPRESSED_BYTES, PARCOUNT, "nonleaf nodes flushed to disk (for checkpoint) (uncompressed bytes)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_DISK_FLUSH_NONLEAF_TOKUTIME_FOR_CHECKPOINT,              NONLEAF_NODES_FLUSHED_TO_DISK_CHECKPOINT_SECONDS, TOKUTIME, "nonleaf nodes flushed to disk (for checkpoint) (seconds)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_DISK_FLUSH_LEAF_COMPRESSION_RATIO,                       LEAF_NODE_COMPRESSION_RATIO, DOUBLE, "uncompressed / compressed bytes written (leaf)", TOKU_GLOBAL_STATUS|TOKU_ENGINE_STATUS);
+    FT_STATUS_INIT(FT_DISK_FLUSH_NONLEAF_COMPRESSION_RATIO,                    NONLEAF_NODE_COMPRESSION_RATIO, DOUBLE, "uncompressed / compressed bytes written (nonleaf)", TOKU_GLOBAL_STATUS|TOKU_ENGINE_STATUS);
+    FT_STATUS_INIT(FT_DISK_FLUSH_OVERALL_COMPRESSION_RATIO,                    OVERALL_NODE_COMPRESSION_RATIO, DOUBLE, "uncompressed / compressed bytes written (overall)", TOKU_GLOBAL_STATUS|TOKU_ENGINE_STATUS);
+
+    // CPU time statistics for [de]serialization and [de]compression.
+    FT_STATUS_INIT(FT_LEAF_COMPRESS_TOKUTIME,                                  LEAF_COMPRESSION_TO_MEMORY_SECONDS, TOKUTIME, "leaf compression to memory (seconds)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_LEAF_SERIALIZE_TOKUTIME,                                 LEAF_SERIALIZATION_TO_MEMORY_SECONDS, TOKUTIME, "leaf serialization to memory (seconds)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_LEAF_DECOMPRESS_TOKUTIME,                                LEAF_DECOMPRESSION_TO_MEMORY_SECONDS, TOKUTIME, "leaf decompression to memory (seconds)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_LEAF_DESERIALIZE_TOKUTIME,                               LEAF_DESERIALIZATION_TO_MEMORY_SECONDS, TOKUTIME, "leaf deserialization to memory (seconds)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_NONLEAF_COMPRESS_TOKUTIME,                               NONLEAF_COMPRESSION_TO_MEMORY_SECONDS, TOKUTIME, "nonleaf compression to memory (seconds)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_NONLEAF_SERIALIZE_TOKUTIME,                              NONLEAF_SERIALIZATION_TO_MEMORY_SECONDS, TOKUTIME, "nonleaf serialization to memory (seconds)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_NONLEAF_DECOMPRESS_TOKUTIME,                             NONLEAF_DECOMPRESSION_TO_MEMORY_SECONDS, TOKUTIME, "nonleaf decompression to memory (seconds)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_NONLEAF_DESERIALIZE_TOKUTIME,                            NONLEAF_DESERIALIZATION_TO_MEMORY_SECONDS, TOKUTIME, "nonleaf deserialization to memory (seconds)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+
+    // Promotion statistics.
+    FT_STATUS_INIT(FT_PRO_NUM_ROOT_SPLIT,                     PROMOTION_ROOTS_SPLIT, PARCOUNT, "promotion: roots split", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_PRO_NUM_ROOT_H0_INJECT,                 PROMOTION_LEAF_ROOTS_INJECTED_INTO, PARCOUNT, "promotion: leaf roots injected into", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_PRO_NUM_ROOT_H1_INJECT,                 PROMOTION_H1_ROOTS_INJECTED_INTO, PARCOUNT, "promotion: h1 roots injected into", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_PRO_NUM_INJECT_DEPTH_0,                 PROMOTION_INJECTIONS_AT_DEPTH_0, PARCOUNT, "promotion: injections at depth 0", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_PRO_NUM_INJECT_DEPTH_1,                 PROMOTION_INJECTIONS_AT_DEPTH_1, PARCOUNT, "promotion: injections at depth 1", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_PRO_NUM_INJECT_DEPTH_2,                 PROMOTION_INJECTIONS_AT_DEPTH_2, PARCOUNT, "promotion: injections at depth 2", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_PRO_NUM_INJECT_DEPTH_3,                 PROMOTION_INJECTIONS_AT_DEPTH_3, PARCOUNT, "promotion: injections at depth 3", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_PRO_NUM_INJECT_DEPTH_GT3,               PROMOTION_INJECTIONS_LOWER_THAN_DEPTH_3, PARCOUNT, "promotion: injections lower than depth 3", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_PRO_NUM_STOP_NONEMPTY_BUF,              PROMOTION_STOPPED_NONEMPTY_BUFFER, PARCOUNT, "promotion: stopped because of a nonempty buffer", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_PRO_NUM_STOP_H1,                        PROMOTION_STOPPED_AT_HEIGHT_1, PARCOUNT, "promotion: stopped at height 1", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_PRO_NUM_STOP_LOCK_CHILD,                PROMOTION_STOPPED_CHILD_LOCKED_OR_NOT_IN_MEMORY, PARCOUNT, "promotion: stopped because the child was locked or not at all in memory", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_PRO_NUM_STOP_CHILD_INMEM,               PROMOTION_STOPPED_CHILD_NOT_FULLY_IN_MEMORY, PARCOUNT, "promotion: stopped because the child was not fully in memory", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_PRO_NUM_DIDNT_WANT_PROMOTE,             PROMOTION_STOPPED_AFTER_LOCKING_CHILD, PARCOUNT, "promotion: stopped anyway, after locking the child", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_BASEMENT_DESERIALIZE_FIXED_KEYSIZE,     BASEMENT_DESERIALIZATION_FIXED_KEY, PARCOUNT, "basement nodes deserialized with fixed-keysize", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_BASEMENT_DESERIALIZE_VARIABLE_KEYSIZE,  BASEMENT_DESERIALIZATION_VARIABLE_KEY, PARCOUNT, "basement nodes deserialized with variable-keysize", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    FT_STATUS_INIT(FT_PRO_RIGHTMOST_LEAF_SHORTCUT_SUCCESS,    nullptr, PARCOUNT, "promotion: succeeded in using the rightmost leaf shortcut", TOKU_ENGINE_STATUS);
+    FT_STATUS_INIT(FT_PRO_RIGHTMOST_LEAF_SHORTCUT_FAIL_POS,   nullptr, PARCOUNT, "promotion: tried the rightmost leaf shorcut but failed (out-of-bounds)", TOKU_ENGINE_STATUS);
+    FT_STATUS_INIT(FT_PRO_RIGHTMOST_LEAF_SHORTCUT_FAIL_REACTIVE,nullptr, PARCOUNT, "promotion: tried the rightmost leaf shorcut but failed (child reactive)", TOKU_ENGINE_STATUS);
+
+    FT_STATUS_INIT(FT_CURSOR_SKIP_DELETED_LEAF_ENTRY,         CURSOR_SKIP_DELETED_LEAF_ENTRY, PARCOUNT, "cursor skipped deleted leaf entries", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+
+    m_initialized = true;
+#undef FT_STATUS_INIT
+}
+void FT_STATUS_S::destroy() {
+    if (!m_initialized) return;
+    for (int i = 0; i < FT_STATUS_NUM_ROWS; ++i) {
+        if (status[i].type == PARCOUNT) {
+            destroy_partitioned_counter(status[i].value.parcount);
+        }
+    }
+}
+
+
+
+FT_FLUSHER_STATUS_S fl_status;
+void FT_FLUSHER_STATUS_S::init() {
+    if (m_initialized) return;
+#define FL_STATUS_INIT(k,c,t,l,inc) TOKUFT_STATUS_INIT((*this), k, c, t, "ft flusher: " l, inc)
+    FL_STATUS_INIT(FT_FLUSHER_CLEANER_TOTAL_NODES,                nullptr, UINT64, "total nodes potentially flushed by cleaner thread", TOKU_ENGINE_STATUS);
+    FL_STATUS_INIT(FT_FLUSHER_CLEANER_H1_NODES,                   nullptr, UINT64, "height-one nodes flushed by cleaner thread", TOKU_ENGINE_STATUS);
+    FL_STATUS_INIT(FT_FLUSHER_CLEANER_HGT1_NODES,                 nullptr, UINT64, "height-greater-than-one nodes flushed by cleaner thread", TOKU_ENGINE_STATUS);
+    FL_STATUS_INIT(FT_FLUSHER_CLEANER_EMPTY_NODES,                nullptr, UINT64, "nodes cleaned which had empty buffers", TOKU_ENGINE_STATUS);
+    FL_STATUS_INIT(FT_FLUSHER_CLEANER_NODES_DIRTIED,              nullptr, UINT64, "nodes dirtied by cleaner thread", TOKU_ENGINE_STATUS);
+    FL_STATUS_INIT(FT_FLUSHER_CLEANER_MAX_BUFFER_SIZE,            nullptr, UINT64, "max bytes in a buffer flushed by cleaner thread", TOKU_ENGINE_STATUS);
+    FL_STATUS_INIT(FT_FLUSHER_CLEANER_MIN_BUFFER_SIZE,            nullptr, UINT64, "min bytes in a buffer flushed by cleaner thread", TOKU_ENGINE_STATUS);
+    FL_STATUS_INIT(FT_FLUSHER_CLEANER_TOTAL_BUFFER_SIZE,          nullptr, UINT64, "total bytes in buffers flushed by cleaner thread", TOKU_ENGINE_STATUS);
+    FL_STATUS_INIT(FT_FLUSHER_CLEANER_MAX_BUFFER_WORKDONE,        nullptr, UINT64, "max workdone in a buffer flushed by cleaner thread", TOKU_ENGINE_STATUS);
+    FL_STATUS_INIT(FT_FLUSHER_CLEANER_MIN_BUFFER_WORKDONE,        nullptr, UINT64, "min workdone in a buffer flushed by cleaner thread", TOKU_ENGINE_STATUS);
+    FL_STATUS_INIT(FT_FLUSHER_CLEANER_TOTAL_BUFFER_WORKDONE,      nullptr, UINT64, "total workdone in buffers flushed by cleaner thread", TOKU_ENGINE_STATUS);
+    FL_STATUS_INIT(FT_FLUSHER_CLEANER_NUM_LEAF_MERGES_STARTED,    nullptr, UINT64, "times cleaner thread tries to merge a leaf", TOKU_ENGINE_STATUS);
+    FL_STATUS_INIT(FT_FLUSHER_CLEANER_NUM_LEAF_MERGES_RUNNING,    nullptr, UINT64, "cleaner thread leaf merges in progress", TOKU_ENGINE_STATUS);
+    FL_STATUS_INIT(FT_FLUSHER_CLEANER_NUM_LEAF_MERGES_COMPLETED,  nullptr, UINT64, "cleaner thread leaf merges successful", TOKU_ENGINE_STATUS);
+    FL_STATUS_INIT(FT_FLUSHER_CLEANER_NUM_DIRTIED_FOR_LEAF_MERGE, nullptr, UINT64, "nodes dirtied by cleaner thread leaf merges", TOKU_ENGINE_STATUS);
+    FL_STATUS_INIT(FT_FLUSHER_FLUSH_TOTAL,                        nullptr, UINT64, "total number of flushes done by flusher threads or cleaner threads", TOKU_ENGINE_STATUS);
+    FL_STATUS_INIT(FT_FLUSHER_FLUSH_IN_MEMORY,                    nullptr, UINT64, "number of in memory flushes", TOKU_ENGINE_STATUS);
+    FL_STATUS_INIT(FT_FLUSHER_FLUSH_NEEDED_IO,                    nullptr, UINT64, "number of flushes that read something off disk", TOKU_ENGINE_STATUS);
+    FL_STATUS_INIT(FT_FLUSHER_FLUSH_CASCADES,                     nullptr, UINT64, "number of flushes that triggered another flush in child", TOKU_ENGINE_STATUS);
+    FL_STATUS_INIT(FT_FLUSHER_FLUSH_CASCADES_1,                   nullptr, UINT64, "number of flushes that triggered 1 cascading flush", TOKU_ENGINE_STATUS);
+    FL_STATUS_INIT(FT_FLUSHER_FLUSH_CASCADES_2,                   nullptr, UINT64, "number of flushes that triggered 2 cascading flushes", TOKU_ENGINE_STATUS);
+    FL_STATUS_INIT(FT_FLUSHER_FLUSH_CASCADES_3,                   nullptr, UINT64, "number of flushes that triggered 3 cascading flushes", TOKU_ENGINE_STATUS);
+    FL_STATUS_INIT(FT_FLUSHER_FLUSH_CASCADES_4,                   nullptr, UINT64, "number of flushes that triggered 4 cascading flushes", TOKU_ENGINE_STATUS);
+    FL_STATUS_INIT(FT_FLUSHER_FLUSH_CASCADES_5,                   nullptr, UINT64, "number of flushes that triggered 5 cascading flushes", TOKU_ENGINE_STATUS);
+    FL_STATUS_INIT(FT_FLUSHER_FLUSH_CASCADES_GT_5,                nullptr, UINT64, "number of flushes that triggered over 5 cascading flushes", TOKU_ENGINE_STATUS);
+    FL_STATUS_INIT(FT_FLUSHER_SPLIT_LEAF,                         nullptr, UINT64, "leaf node splits", TOKU_ENGINE_STATUS);
+    FL_STATUS_INIT(FT_FLUSHER_SPLIT_NONLEAF,                      nullptr, UINT64, "nonleaf node splits", TOKU_ENGINE_STATUS);
+    FL_STATUS_INIT(FT_FLUSHER_MERGE_LEAF,                         nullptr, UINT64, "leaf node merges", TOKU_ENGINE_STATUS);
+    FL_STATUS_INIT(FT_FLUSHER_MERGE_NONLEAF,                      nullptr, UINT64, "nonleaf node merges", TOKU_ENGINE_STATUS);
+    FL_STATUS_INIT(FT_FLUSHER_BALANCE_LEAF,                       nullptr, UINT64, "leaf node balances", TOKU_ENGINE_STATUS);
+
+    FL_STATUS_VAL(FT_FLUSHER_CLEANER_MIN_BUFFER_SIZE) = UINT64_MAX;
+    FL_STATUS_VAL(FT_FLUSHER_CLEANER_MIN_BUFFER_WORKDONE) = UINT64_MAX;
+
+    m_initialized = true;
+#undef FL_STATUS_INIT
+}
+void FT_FLUSHER_STATUS_S::destroy() {
+    if (!m_initialized) return;
+    for (int i = 0; i < FT_FLUSHER_STATUS_NUM_ROWS; ++i) {
+        if (status[i].type == PARCOUNT) {
+            destroy_partitioned_counter(status[i].value.parcount);
+        }
+    }
+}
+
+
+
+FT_HOT_STATUS_S hot_status;
+void FT_HOT_STATUS_S::init() {
+    if (m_initialized) return;
+#define HOT_STATUS_INIT(k,c,t,l,inc) TOKUFT_STATUS_INIT((*this), k, c, t, "hot: " l, inc)
+    HOT_STATUS_INIT(FT_HOT_NUM_STARTED,          nullptr, UINT64, "operations ever started", TOKU_ENGINE_STATUS);
+    HOT_STATUS_INIT(FT_HOT_NUM_COMPLETED,        nullptr, UINT64, "operations successfully completed", TOKU_ENGINE_STATUS);
+    HOT_STATUS_INIT(FT_HOT_NUM_ABORTED,          nullptr, UINT64, "operations aborted", TOKU_ENGINE_STATUS);
+    HOT_STATUS_INIT(FT_HOT_MAX_ROOT_FLUSH_COUNT, nullptr, UINT64, "max number of flushes from root ever required to optimize a tree", TOKU_ENGINE_STATUS);
+
+    m_initialized = true;
+#undef HOT_STATUS_INIT
+}
+void FT_HOT_STATUS_S::destroy() {
+    if (!m_initialized) return;
+    for (int i = 0; i < FT_HOT_STATUS_NUM_ROWS; ++i) {
+        if (status[i].type == PARCOUNT) {
+            destroy_partitioned_counter(status[i].value.parcount);
+        }
+    }
+}
+
+
+
+TXN_STATUS_S txn_status;
+void TXN_STATUS_S::init() {
+    if (m_initialized) return;
+#define TXN_STATUS_INIT(k,c,t,l,inc) TOKUFT_STATUS_INIT((*this), k, c, t, "txn: " l, inc)
+    TXN_STATUS_INIT(TXN_BEGIN,            TXN_BEGIN, PARCOUNT,   "begin", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    TXN_STATUS_INIT(TXN_READ_BEGIN,       TXN_BEGIN_READ_ONLY, PARCOUNT,   "begin read only", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    TXN_STATUS_INIT(TXN_COMMIT,           TXN_COMMITS, PARCOUNT,   "successful commits", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    TXN_STATUS_INIT(TXN_ABORT,            TXN_ABORTS, PARCOUNT,   "aborts", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    m_initialized = true;
+#undef TXN_STATUS_INIT
+}
+void TXN_STATUS_S::destroy() {
+    if (!m_initialized) return;
+    for (int i = 0; i < TXN_STATUS_NUM_ROWS; ++i) {
+        if (status[i].type == PARCOUNT) {
+            destroy_partitioned_counter(status[i].value.parcount);
+        }
+    }
+}
+
+
+LOGGER_STATUS_S log_status;
+void LOGGER_STATUS_S::init() {
+    if (m_initialized) return;
+#define LOG_STATUS_INIT(k,c,t,l,inc) TOKUFT_STATUS_INIT((*this), k, c, t, "logger: " l, inc)
+    LOG_STATUS_INIT(LOGGER_NEXT_LSN,     nullptr, UINT64,  "next LSN", TOKU_ENGINE_STATUS);
+    LOG_STATUS_INIT(LOGGER_NUM_WRITES,                  LOGGER_WRITES, UINT64, "writes", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    LOG_STATUS_INIT(LOGGER_BYTES_WRITTEN,               LOGGER_WRITES_BYTES, UINT64, "writes (bytes)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    LOG_STATUS_INIT(LOGGER_UNCOMPRESSED_BYTES_WRITTEN,  LOGGER_WRITES_UNCOMPRESSED_BYTES, UINT64, "writes (uncompressed bytes)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    LOG_STATUS_INIT(LOGGER_TOKUTIME_WRITES,             LOGGER_WRITES_SECONDS, TOKUTIME, "writes (seconds)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    LOG_STATUS_INIT(LOGGER_WAIT_BUF_LONG,               LOGGER_WAIT_LONG, UINT64, "number of long logger write operations", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
+    m_initialized = true;
+#undef LOG_STATUS_INIT
+}
+void LOGGER_STATUS_S::destroy() {
+    if (!m_initialized) return;
+    for (int i = 0; i < LOGGER_STATUS_NUM_ROWS; ++i) {
+        if (status[i].type == PARCOUNT) {
+            destroy_partitioned_counter(status[i].value.parcount);
+        }
+    }
+}
+
+void toku_status_init(void) {
+    le_status.init();
+    cp_status.init();
+    ltm_status.init();
+    ft_status.init();
+    fl_status.init();
+    hot_status.init();
+    txn_status.init();
+    log_status.init();
+}
+void toku_status_destroy(void) {
+    log_status.destroy();
+    txn_status.destroy();
+    hot_status.destroy();
+    fl_status.destroy();
+    ft_status.destroy();
+    ltm_status.destroy();
+    cp_status.destroy();
+    le_status.destroy();
+}

--- a/ft/ft-status.h
+++ b/ft/ft-status.h
@@ -1,0 +1,556 @@
+/* -*- mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+// vim: ft=cpp:expandtab:ts=8:sw=4:softtabstop=4:
+
+#ident "$Id$"
+/*
+COPYING CONDITIONS NOTICE:
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of version 2 of the GNU General Public License as
+  published by the Free Software Foundation, and provided that the
+  following conditions are met:
+
+      * Redistributions of source code must retain this COPYING
+        CONDITIONS NOTICE, the COPYRIGHT NOTICE (below), the
+        DISCLAIMER (below), the UNIVERSITY PATENT NOTICE (below), the
+        PATENT MARKING NOTICE (below), and the PATENT RIGHTS
+        GRANT (below).
+
+      * Redistributions in binary form must reproduce this COPYING
+        CONDITIONS NOTICE, the COPYRIGHT NOTICE (below), the
+        DISCLAIMER (below), the UNIVERSITY PATENT NOTICE (below), the
+        PATENT MARKING NOTICE (below), and the PATENT RIGHTS
+        GRANT (below) in the documentation and/or other materials
+        provided with the distribution.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+  02110-1301, USA.
+
+COPYRIGHT NOTICE:
+
+  TokuFT, Tokutek Fractal Tree Indexing Library.
+  Copyright (C) 2007-2013 Tokutek, Inc.
+
+DISCLAIMER:
+
+  This program is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  General Public License for more details.
+
+UNIVERSITY PATENT NOTICE:
+
+  The technology is licensed by the Massachusetts Institute of
+  Technology, Rutgers State University of New Jersey, and the Research
+  Foundation of State University of New York at Stony Brook under
+  United States of America Serial No. 11/760379 and to the patents
+  and/or patent applications resulting from it.
+
+PATENT MARKING NOTICE:
+
+  This software is covered by US Patent No. 8,185,551.
+  This software is covered by US Patent No. 8,489,638.
+
+PATENT RIGHTS GRANT:
+
+  "THIS IMPLEMENTATION" means the copyrightable works distributed by
+  Tokutek as part of the Fractal Tree project.
+
+  "PATENT CLAIMS" means the claims of patents that are owned or
+  licensable by Tokutek, both currently or in the future; and that in
+  the absence of this license would be infringed by THIS
+  IMPLEMENTATION or by using or running THIS IMPLEMENTATION.
+
+  "PATENT CHALLENGE" shall mean a challenge to the validity,
+  patentability, enforceability and/or non-infringement of any of the
+  PATENT CLAIMS or otherwise opposing any of the PATENT CLAIMS.
+
+  Tokutek hereby grants to you, for the term and geographical scope of
+  the PATENT CLAIMS, a non-exclusive, no-charge, royalty-free,
+  irrevocable (except as stated in this section) patent license to
+  make, have made, use, offer to sell, sell, import, transfer, and
+  otherwise run, modify, and propagate the contents of THIS
+  IMPLEMENTATION, where such license applies only to the PATENT
+  CLAIMS.  This grant does not include claims that would be infringed
+  only as a consequence of further modifications of THIS
+  IMPLEMENTATION.  If you or your agent or licensee institute or order
+  or agree to the institution of patent litigation against any entity
+  (including a cross-claim or counterclaim in a lawsuit) alleging that
+  THIS IMPLEMENTATION constitutes direct or contributory patent
+  infringement, or inducement of patent infringement, then any rights
+  granted to you under this License shall terminate as of the date
+  such litigation is filed.  If you or your agent or exclusive
+  licensee institute or order or agree to the institution of a PATENT
+  CHALLENGE, then Tokutek may terminate any rights granted to you
+  under this License.
+*/
+
+#pragma once
+
+#ident "Copyright (c) 2007-2013 Tokutek Inc.  All rights reserved."
+#ident "The technology is licensed by the Massachusetts Institute of Technology, Rutgers State University of New Jersey, and the Research Foundation of State University of New York at Stony Brook under United States of America Serial No. 11/760379 and to the patents and/or patent applications resulting from it."
+
+#include <db.h>
+
+#include "portability/toku_config.h"
+#include "portability/toku_list.h"
+#include "portability/toku_race_tools.h"
+
+#include "util/status.h"
+
+//
+// Leaf Entry statistics
+//
+class LE_STATUS_S {
+public:
+    enum {
+        LE_MAX_COMMITTED_XR = 0,
+        LE_MAX_PROVISIONAL_XR,
+        LE_EXPANDED,
+        LE_MAX_MEMSIZE,
+        LE_APPLY_GC_BYTES_IN,
+        LE_APPLY_GC_BYTES_OUT,
+        LE_NORMAL_GC_BYTES_IN,
+        LE_NORMAL_GC_BYTES_OUT,
+        LE_STATUS_NUM_ROWS
+    };
+
+    void init();
+    void destroy();
+
+    TOKU_ENGINE_STATUS_ROW_S status[LE_STATUS_NUM_ROWS];
+
+private:
+    bool m_initialized;
+};
+typedef LE_STATUS_S* LE_STATUS;
+extern LE_STATUS_S le_status;
+
+// executed too often to be worth making threadsafe
+#define LE_STATUS_VAL(x) le_status.status[LE_STATUS_S::x].value.num
+#define LE_STATUS_INC(x, d)                                                         \
+    do {                                                                            \
+        if (le_status.status[LE_STATUS_S::x].type == PARCOUNT) {                                 \
+            increment_partitioned_counter(le_status.status[LE_STATUS_S::x].value.parcount, d);   \
+        } else {                                                                    \
+            toku_sync_fetch_and_add(&le_status.status[LE_STATUS_S::x].value.num, d);             \
+        }                                                                           \
+    } while (0)
+
+
+
+//
+// Checkpoint statistics
+//
+class CHECKPOINT_STATUS_S {
+public:
+    enum {
+        CP_PERIOD,
+        CP_FOOTPRINT,
+        CP_TIME_LAST_CHECKPOINT_BEGIN,
+        CP_TIME_LAST_CHECKPOINT_BEGIN_COMPLETE,
+        CP_TIME_LAST_CHECKPOINT_END,
+        CP_TIME_CHECKPOINT_DURATION,
+        CP_TIME_CHECKPOINT_DURATION_LAST,
+        CP_LAST_LSN,
+        CP_CHECKPOINT_COUNT,
+        CP_CHECKPOINT_COUNT_FAIL,
+        CP_WAITERS_NOW,          // how many threads are currently waiting for the checkpoint_safe lock to perform a checkpoint
+        CP_WAITERS_MAX,          // max threads ever simultaneously waiting for the checkpoint_safe lock to perform a checkpoint
+        CP_CLIENT_WAIT_ON_MO,    // how many times a client thread waited to take the multi_operation lock, not for checkpoint
+        CP_CLIENT_WAIT_ON_CS,    // how many times a client thread waited for the checkpoint_safe lock, not for checkpoint
+        CP_BEGIN_TIME,
+        CP_LONG_BEGIN_TIME,
+        CP_LONG_BEGIN_COUNT,
+        CP_STATUS_NUM_ROWS       // number of rows in this status array.  must be last.
+    };
+
+    void init();
+    void destroy();
+
+    TOKU_ENGINE_STATUS_ROW_S status[CP_STATUS_NUM_ROWS];
+
+private:
+    bool m_initialized;
+};
+typedef CHECKPOINT_STATUS_S* CHECKPOINT_STATUS;
+extern CHECKPOINT_STATUS_S cp_status;
+
+#define CP_STATUS_VAL(x) cp_status.status[CHECKPOINT_STATUS_S::x].value.num
+
+
+
+//
+// Cachetable statistics
+//
+class CACHETABLE_STATUS_S {
+public:
+    enum {
+        CT_MISS = 0,
+        CT_MISSTIME,               // how many usec spent waiting for disk read because of cache miss
+        CT_PREFETCHES,             // how many times has a block been prefetched into the cachetable?
+        CT_SIZE_CURRENT,           // the sum of the sizes of the nodes represented in the cachetable
+        CT_SIZE_LIMIT,             // the limit to the sum of the node sizes
+        CT_SIZE_WRITING,           // the sum of the sizes of the nodes being written
+        CT_SIZE_NONLEAF,           // number of bytes in cachetable belonging to nonleaf nodes
+        CT_SIZE_LEAF,              // number of bytes in cachetable belonging to leaf nodes
+        CT_SIZE_ROLLBACK,          // number of bytes in cachetable belonging to rollback nodes
+        CT_SIZE_CACHEPRESSURE,     // number of bytes causing cache pressure (sum of buffers and workdone counters)
+        CT_SIZE_CLONED,            // number of bytes of cloned data in the system
+        CT_EVICTIONS,
+        CT_CLEANER_EXECUTIONS,     // number of times the cleaner thread's loop has executed
+        CT_CLEANER_PERIOD,
+        CT_CLEANER_ITERATIONS,     // number of times the cleaner thread runs the cleaner per period
+        CT_WAIT_PRESSURE_COUNT,
+        CT_WAIT_PRESSURE_TIME,
+        CT_LONG_WAIT_PRESSURE_COUNT,
+        CT_LONG_WAIT_PRESSURE_TIME,
+        CT_STATUS_NUM_ROWS
+    };
+
+    void init();
+    void destroy();
+    
+    TOKU_ENGINE_STATUS_ROW_S status[CT_STATUS_NUM_ROWS];
+
+private:
+    bool m_initialized;
+};
+typedef CACHETABLE_STATUS_S* CACHETABLE_STATUS;
+extern CACHETABLE_STATUS_S ct_status;
+
+#define CT_STATUS_VAL(x) ct_status.status[CACHETABLE_STATUS_S::x].value.num
+
+
+
+//
+// Lock Tree Manager statistics
+//
+class LTM_STATUS_S {
+public:
+    enum {
+        LTM_SIZE_CURRENT = 0,
+        LTM_SIZE_LIMIT,
+        LTM_ESCALATION_COUNT,
+        LTM_ESCALATION_TIME,
+        LTM_ESCALATION_LATEST_RESULT,
+        LTM_NUM_LOCKTREES,
+        LTM_LOCK_REQUESTS_PENDING,
+        LTM_STO_NUM_ELIGIBLE,
+        LTM_STO_END_EARLY_COUNT,
+        LTM_STO_END_EARLY_TIME,
+        LTM_WAIT_COUNT,
+        LTM_WAIT_TIME,
+        LTM_LONG_WAIT_COUNT,
+        LTM_LONG_WAIT_TIME,
+        LTM_TIMEOUT_COUNT,
+        LTM_WAIT_ESCALATION_COUNT,
+        LTM_WAIT_ESCALATION_TIME,
+        LTM_LONG_WAIT_ESCALATION_COUNT,
+        LTM_LONG_WAIT_ESCALATION_TIME,
+        LTM_STATUS_NUM_ROWS // must be last
+    };
+
+    void init(void);
+    void destroy(void);
+
+    TOKU_ENGINE_STATUS_ROW_S status[LTM_STATUS_NUM_ROWS];
+
+private:
+    bool m_initialized;
+};
+typedef  LTM_STATUS_S* LTM_STATUS;
+extern LTM_STATUS_S ltm_status;
+
+#define LTM_STATUS_VAL(x) ltm_status.status[LTM_STATUS_S::x].value.num
+
+
+//
+// Fractal Tree statistics
+//
+class FT_STATUS_S {
+public:
+    enum {
+        FT_UPDATES = 0,
+        FT_UPDATES_BROADCAST,
+        FT_DESCRIPTOR_SET,
+        FT_MSN_DISCARDS,                           // how many messages were ignored by leaf because of msn
+        FT_TOTAL_RETRIES,                          // total number of search retries due to TRY_AGAIN
+        FT_SEARCH_TRIES_GT_HEIGHT,                 // number of searches that required more tries than the height of the tree
+        FT_SEARCH_TRIES_GT_HEIGHTPLUS3,            // number of searches that required more tries than the height of the tree plus three
+        FT_DISK_FLUSH_LEAF,                        // number of leaf nodes flushed to disk,    not for checkpoint
+        FT_DISK_FLUSH_LEAF_BYTES,                  // number of leaf nodes flushed to disk,    not for checkpoint
+        FT_DISK_FLUSH_LEAF_UNCOMPRESSED_BYTES,     // number of leaf nodes flushed to disk,    not for checkpoint
+        FT_DISK_FLUSH_LEAF_TOKUTIME,               // number of leaf nodes flushed to disk,    not for checkpoint
+        FT_DISK_FLUSH_NONLEAF,                     // number of nonleaf nodes flushed to disk, not for checkpoint
+        FT_DISK_FLUSH_NONLEAF_BYTES,               // number of nonleaf nodes flushed to disk, not for checkpoint
+        FT_DISK_FLUSH_NONLEAF_UNCOMPRESSED_BYTES,  // number of nonleaf nodes flushed to disk, not for checkpoint
+        FT_DISK_FLUSH_NONLEAF_TOKUTIME,            // number of nonleaf nodes flushed to disk, not for checkpoint
+        FT_DISK_FLUSH_LEAF_FOR_CHECKPOINT,         // number of leaf nodes flushed to disk for checkpoint
+        FT_DISK_FLUSH_LEAF_BYTES_FOR_CHECKPOINT,   // number of leaf nodes flushed to disk for checkpoint
+        FT_DISK_FLUSH_LEAF_UNCOMPRESSED_BYTES_FOR_CHECKPOINT,// number of leaf nodes flushed to disk for checkpoint
+        FT_DISK_FLUSH_LEAF_TOKUTIME_FOR_CHECKPOINT,// number of leaf nodes flushed to disk for checkpoint
+        FT_DISK_FLUSH_NONLEAF_FOR_CHECKPOINT,      // number of nonleaf nodes flushed to disk for checkpoint
+        FT_DISK_FLUSH_NONLEAF_BYTES_FOR_CHECKPOINT,// number of nonleaf nodes flushed to disk for checkpoint
+        FT_DISK_FLUSH_NONLEAF_UNCOMPRESSED_BYTES_FOR_CHECKPOINT,// number of nonleaf nodes flushed to disk for checkpoint
+        FT_DISK_FLUSH_NONLEAF_TOKUTIME_FOR_CHECKPOINT,// number of nonleaf nodes flushed to disk for checkpoint
+        FT_DISK_FLUSH_LEAF_COMPRESSION_RATIO,      // effective compression ratio for leaf bytes flushed to disk
+        FT_DISK_FLUSH_NONLEAF_COMPRESSION_RATIO,   // effective compression ratio for nonleaf bytes flushed to disk
+        FT_DISK_FLUSH_OVERALL_COMPRESSION_RATIO,   // effective compression ratio for all bytes flushed to disk
+        FT_PARTIAL_EVICTIONS_NONLEAF,              // number of nonleaf node partial evictions
+        FT_PARTIAL_EVICTIONS_NONLEAF_BYTES,        // number of nonleaf node partial evictions
+        FT_PARTIAL_EVICTIONS_LEAF,                 // number of leaf node partial evictions
+        FT_PARTIAL_EVICTIONS_LEAF_BYTES,           // number of leaf node partial evictions
+        FT_FULL_EVICTIONS_LEAF,                    // number of full cachetable evictions on leaf nodes
+        FT_FULL_EVICTIONS_LEAF_BYTES,              // number of full cachetable evictions on leaf nodes (bytes)
+        FT_FULL_EVICTIONS_NONLEAF,                 // number of full cachetable evictions on nonleaf nodes
+        FT_FULL_EVICTIONS_NONLEAF_BYTES,           // number of full cachetable evictions on nonleaf nodes (bytes)
+        FT_CREATE_LEAF,                            // number of leaf nodes created
+        FT_CREATE_NONLEAF,                         // number of nonleaf nodes created
+        FT_DESTROY_LEAF,                           // number of leaf nodes destroyed
+        FT_DESTROY_NONLEAF,                        // number of nonleaf nodes destroyed
+        FT_MSG_BYTES_IN,                           // how many bytes of messages injected at root (for all trees)
+        FT_MSG_BYTES_OUT,                          // how many bytes of messages flushed from h1 nodes to leaves
+        FT_MSG_BYTES_CURR,                         // how many bytes of messages currently in trees (estimate)
+        FT_MSG_NUM,                                // how many messages injected at root
+        FT_MSG_NUM_BROADCAST,                      // how many broadcast messages injected at root
+        FT_NUM_BASEMENTS_DECOMPRESSED_NORMAL,      // how many basement nodes were decompressed because they were the target of a query
+        FT_NUM_BASEMENTS_DECOMPRESSED_AGGRESSIVE,  // ... because they were between lc and rc
+        FT_NUM_BASEMENTS_DECOMPRESSED_PREFETCH,
+        FT_NUM_BASEMENTS_DECOMPRESSED_WRITE,
+        FT_NUM_MSG_BUFFER_DECOMPRESSED_NORMAL,     // how many msg buffers were decompressed because they were the target of a query
+        FT_NUM_MSG_BUFFER_DECOMPRESSED_AGGRESSIVE, // ... because they were between lc and rc
+        FT_NUM_MSG_BUFFER_DECOMPRESSED_PREFETCH,
+        FT_NUM_MSG_BUFFER_DECOMPRESSED_WRITE,
+        FT_NUM_PIVOTS_FETCHED_QUERY,               // how many pivots were fetched for a query
+        FT_BYTES_PIVOTS_FETCHED_QUERY,             // how many pivots were fetched for a query
+        FT_TOKUTIME_PIVOTS_FETCHED_QUERY,          // how many pivots were fetched for a query
+        FT_NUM_PIVOTS_FETCHED_PREFETCH,            // ... for a prefetch
+        FT_BYTES_PIVOTS_FETCHED_PREFETCH,          // ... for a prefetch
+        FT_TOKUTIME_PIVOTS_FETCHED_PREFETCH,       // ... for a prefetch
+        FT_NUM_PIVOTS_FETCHED_WRITE,               // ... for a write
+        FT_BYTES_PIVOTS_FETCHED_WRITE,             // ... for a write
+        FT_TOKUTIME_PIVOTS_FETCHED_WRITE,          // ... for a write
+        FT_NUM_BASEMENTS_FETCHED_NORMAL,           // how many basement nodes were fetched because they were the target of a query
+        FT_BYTES_BASEMENTS_FETCHED_NORMAL,         // how many basement nodes were fetched because they were the target of a query
+        FT_TOKUTIME_BASEMENTS_FETCHED_NORMAL,      // how many basement nodes were fetched because they were the target of a query
+        FT_NUM_BASEMENTS_FETCHED_AGGRESSIVE,       // ... because they were between lc and rc
+        FT_BYTES_BASEMENTS_FETCHED_AGGRESSIVE,     // ... because they were between lc and rc
+        FT_TOKUTIME_BASEMENTS_FETCHED_AGGRESSIVE,  // ... because they were between lc and rc
+        FT_NUM_BASEMENTS_FETCHED_PREFETCH,
+        FT_BYTES_BASEMENTS_FETCHED_PREFETCH,
+        FT_TOKUTIME_BASEMENTS_FETCHED_PREFETCH,
+        FT_NUM_BASEMENTS_FETCHED_WRITE,
+        FT_BYTES_BASEMENTS_FETCHED_WRITE,
+        FT_TOKUTIME_BASEMENTS_FETCHED_WRITE,
+        FT_NUM_MSG_BUFFER_FETCHED_NORMAL,          // how many msg buffers were fetched because they were the target of a query
+        FT_BYTES_MSG_BUFFER_FETCHED_NORMAL,        // how many msg buffers were fetched because they were the target of a query
+        FT_TOKUTIME_MSG_BUFFER_FETCHED_NORMAL,     // how many msg buffers were fetched because they were the target of a query
+        FT_NUM_MSG_BUFFER_FETCHED_AGGRESSIVE,      // ... because they were between lc and rc
+        FT_BYTES_MSG_BUFFER_FETCHED_AGGRESSIVE,    // ... because they were between lc and rc
+        FT_TOKUTIME_MSG_BUFFER_FETCHED_AGGRESSIVE, // ... because they were between lc and rc
+        FT_NUM_MSG_BUFFER_FETCHED_PREFETCH,
+        FT_BYTES_MSG_BUFFER_FETCHED_PREFETCH,
+        FT_TOKUTIME_MSG_BUFFER_FETCHED_PREFETCH,
+        FT_NUM_MSG_BUFFER_FETCHED_WRITE,
+        FT_BYTES_MSG_BUFFER_FETCHED_WRITE,
+        FT_TOKUTIME_MSG_BUFFER_FETCHED_WRITE,
+        FT_LEAF_COMPRESS_TOKUTIME, // seconds spent compressing leaf leaf nodes to memory
+        FT_LEAF_SERIALIZE_TOKUTIME, // seconds spent serializing leaf node to memory
+        FT_LEAF_DECOMPRESS_TOKUTIME, // seconds spent decompressing leaf nodes to memory
+        FT_LEAF_DESERIALIZE_TOKUTIME, // seconds spent deserializing leaf nodes to memory
+        FT_NONLEAF_COMPRESS_TOKUTIME, // seconds spent compressing nonleaf nodes to memory
+        FT_NONLEAF_SERIALIZE_TOKUTIME, // seconds spent serializing nonleaf nodes to memory
+        FT_NONLEAF_DECOMPRESS_TOKUTIME, // seconds spent decompressing nonleaf nodes to memory
+        FT_NONLEAF_DESERIALIZE_TOKUTIME, // seconds spent deserializing nonleaf nodes to memory
+        FT_PRO_NUM_ROOT_SPLIT,
+        FT_PRO_NUM_ROOT_H0_INJECT,
+        FT_PRO_NUM_ROOT_H1_INJECT,
+        FT_PRO_NUM_INJECT_DEPTH_0,
+        FT_PRO_NUM_INJECT_DEPTH_1,
+        FT_PRO_NUM_INJECT_DEPTH_2,
+        FT_PRO_NUM_INJECT_DEPTH_3,
+        FT_PRO_NUM_INJECT_DEPTH_GT3,
+        FT_PRO_NUM_STOP_NONEMPTY_BUF,
+        FT_PRO_NUM_STOP_H1,
+        FT_PRO_NUM_STOP_LOCK_CHILD,
+        FT_PRO_NUM_STOP_CHILD_INMEM,
+        FT_PRO_NUM_DIDNT_WANT_PROMOTE,
+        FT_BASEMENT_DESERIALIZE_FIXED_KEYSIZE, // how many basement nodes were deserialized with a fixed keysize
+        FT_BASEMENT_DESERIALIZE_VARIABLE_KEYSIZE, // how many basement nodes were deserialized with a variable keysize
+        FT_PRO_RIGHTMOST_LEAF_SHORTCUT_SUCCESS,
+        FT_PRO_RIGHTMOST_LEAF_SHORTCUT_FAIL_POS,
+        FT_PRO_RIGHTMOST_LEAF_SHORTCUT_FAIL_REACTIVE,
+        FT_CURSOR_SKIP_DELETED_LEAF_ENTRY, // how many deleted leaf entries were skipped by a cursor
+        FT_STATUS_NUM_ROWS
+    };
+
+    void init(void);
+    void destroy(void);
+
+    TOKU_ENGINE_STATUS_ROW_S status[FT_STATUS_NUM_ROWS];
+
+private:
+    bool m_initialized;
+};
+typedef FT_STATUS_S* FT_STATUS;
+extern FT_STATUS_S ft_status;
+
+#define FT_STATUS_VAL(x)                                                            \
+    (ft_status.status[FT_STATUS_S::x].type == PARCOUNT ?                                         \
+        read_partitioned_counter(ft_status.status[FT_STATUS_S::x].value.parcount) :              \
+        ft_status.status[FT_STATUS_S::x].value.num)
+
+#define FT_STATUS_INC(x, d)                                                         \
+    do {                                                                            \
+        if (ft_status.status[FT_STATUS_S::x].type == PARCOUNT) {                                 \
+            increment_partitioned_counter(ft_status.status[FT_STATUS_S::x].value.parcount, d);   \
+        } else {                                                                    \
+            toku_sync_fetch_and_add(&ft_status.status[FT_STATUS_S::x].value.num, d);             \
+        }                                                                           \
+    } while (0)
+
+
+
+//
+// Flusher statistics
+//
+class FT_FLUSHER_STATUS_S {
+public:
+    enum {
+        FT_FLUSHER_CLEANER_TOTAL_NODES = 0,     // total number of nodes whose buffers are potentially flushed by cleaner thread
+        FT_FLUSHER_CLEANER_H1_NODES,            // number of nodes of height one whose message buffers are flushed by cleaner thread
+        FT_FLUSHER_CLEANER_HGT1_NODES,          // number of nodes of height > 1 whose message buffers are flushed by cleaner thread
+        FT_FLUSHER_CLEANER_EMPTY_NODES,         // number of nodes that are selected by cleaner, but whose buffers are empty
+        FT_FLUSHER_CLEANER_NODES_DIRTIED,       // number of nodes that are made dirty by the cleaner thread
+        FT_FLUSHER_CLEANER_MAX_BUFFER_SIZE,     // max number of bytes in message buffer flushed by cleaner thread
+        FT_FLUSHER_CLEANER_MIN_BUFFER_SIZE,
+        FT_FLUSHER_CLEANER_TOTAL_BUFFER_SIZE,
+        FT_FLUSHER_CLEANER_MAX_BUFFER_WORKDONE, // max workdone value of any message buffer flushed by cleaner thread
+        FT_FLUSHER_CLEANER_MIN_BUFFER_WORKDONE,
+        FT_FLUSHER_CLEANER_TOTAL_BUFFER_WORKDONE,
+        FT_FLUSHER_CLEANER_NUM_LEAF_MERGES_STARTED,     // number of times cleaner thread tries to merge a leaf
+        FT_FLUSHER_CLEANER_NUM_LEAF_MERGES_RUNNING,     // number of cleaner thread leaf merges in progress
+        FT_FLUSHER_CLEANER_NUM_LEAF_MERGES_COMPLETED,   // number of times cleaner thread successfully merges a leaf
+        FT_FLUSHER_CLEANER_NUM_DIRTIED_FOR_LEAF_MERGE,  // nodes dirtied by the "flush from root" process to merge a leaf node
+        FT_FLUSHER_FLUSH_TOTAL,                 // total number of flushes done by flusher threads or cleaner threads
+        FT_FLUSHER_FLUSH_IN_MEMORY,             // number of in memory flushes
+        FT_FLUSHER_FLUSH_NEEDED_IO,             // number of flushes that had to read a child (or part) off disk
+        FT_FLUSHER_FLUSH_CASCADES,              // number of flushes that triggered another flush in the child
+        FT_FLUSHER_FLUSH_CASCADES_1,            // number of flushes that triggered 1 cascading flush
+        FT_FLUSHER_FLUSH_CASCADES_2,            // number of flushes that triggered 2 cascading flushes
+        FT_FLUSHER_FLUSH_CASCADES_3,            // number of flushes that triggered 3 cascading flushes
+        FT_FLUSHER_FLUSH_CASCADES_4,            // number of flushes that triggered 4 cascading flushes
+        FT_FLUSHER_FLUSH_CASCADES_5,            // number of flushes that triggered 5 cascading flushes
+        FT_FLUSHER_FLUSH_CASCADES_GT_5,         // number of flushes that triggered more than 5 cascading flushes
+        FT_FLUSHER_SPLIT_LEAF,                  // number of leaf nodes split
+        FT_FLUSHER_SPLIT_NONLEAF,               // number of nonleaf nodes split
+        FT_FLUSHER_MERGE_LEAF,                  // number of times leaf nodes are merged
+        FT_FLUSHER_MERGE_NONLEAF,               // number of times nonleaf nodes are merged
+        FT_FLUSHER_BALANCE_LEAF,                // number of times a leaf node is balanced
+        FT_FLUSHER_STATUS_NUM_ROWS
+    };
+
+    void init(void);
+    void destroy(void);
+
+    TOKU_ENGINE_STATUS_ROW_S status[FT_FLUSHER_STATUS_NUM_ROWS];
+
+private:
+    bool m_initialized;
+};
+typedef FT_FLUSHER_STATUS_S* FT_FLUSHER_STATUS;
+extern FT_FLUSHER_STATUS_S fl_status;
+
+#define FL_STATUS_VAL(x) fl_status.status[FT_FLUSHER_STATUS_S::x].value.num
+
+
+
+//
+// Hot Flusher
+//
+class FT_HOT_STATUS_S {
+public:
+    enum {
+        FT_HOT_NUM_STARTED = 0,      // number of HOT operations that have begun
+        FT_HOT_NUM_COMPLETED,        // number of HOT operations that have successfully completed
+        FT_HOT_NUM_ABORTED,          // number of HOT operations that have been aborted
+        FT_HOT_MAX_ROOT_FLUSH_COUNT, // max number of flushes from root ever required to optimize a tree
+        FT_HOT_STATUS_NUM_ROWS
+    };
+
+    void init(void);
+    void destroy(void);
+
+    TOKU_ENGINE_STATUS_ROW_S status[FT_HOT_STATUS_NUM_ROWS];
+
+private:
+    bool m_initialized;
+};
+typedef FT_HOT_STATUS_S* FT_HOT_STATUS;
+extern FT_HOT_STATUS_S hot_status;
+
+#define HOT_STATUS_VAL(x) hot_status.status[FT_HOT_STATUS_S::x].value.num
+
+
+
+//
+// Transaction statistics
+//
+class TXN_STATUS_S {
+public:
+    enum {
+        TXN_BEGIN,             // total number of transactions begun (does not include recovered txns)
+        TXN_READ_BEGIN,        // total number of read only transactions begun (does not include recovered txns)
+        TXN_COMMIT,            // successful commits
+        TXN_ABORT,
+        TXN_STATUS_NUM_ROWS
+    };
+
+    void init(void);
+    void destroy(void);
+
+    TOKU_ENGINE_STATUS_ROW_S status[TXN_STATUS_NUM_ROWS];
+
+private:
+    bool m_initialized;
+};
+typedef TXN_STATUS_S* TXN_STATUS;
+extern TXN_STATUS_S txn_status;
+
+#define TXN_STATUS_INC(x, d) increment_partitioned_counter(txn_status.status[TXN_STATUS_S::x].value.parcount, d)
+
+
+
+//
+// Logger statistics
+//
+class LOGGER_STATUS_S {
+public:
+    enum {
+        LOGGER_NEXT_LSN = 0,
+        LOGGER_NUM_WRITES,
+        LOGGER_BYTES_WRITTEN,
+        LOGGER_UNCOMPRESSED_BYTES_WRITTEN,
+        LOGGER_TOKUTIME_WRITES,
+        LOGGER_WAIT_BUF_LONG,
+        LOGGER_STATUS_NUM_ROWS
+    };
+
+    void init(void);
+    void destroy(void);
+
+    TOKU_ENGINE_STATUS_ROW_S status[LOGGER_STATUS_NUM_ROWS];
+
+private:
+    bool m_initialized;
+};
+typedef LOGGER_STATUS_S* LOGGER_STATUS;
+extern LOGGER_STATUS_S log_status;
+
+#define LOG_STATUS_VAL(x) log_status.status[LOGGER_STATUS_S::x].value.num
+
+void toku_status_init(void);
+void toku_status_destroy(void);

--- a/ft/logger/logger.h
+++ b/ft/logger/logger.h
@@ -260,21 +260,6 @@ void toku_logger_maybe_fsync (TOKULOGGER logger, LSN lsn, int do_fsync, bool hol
 //        fsync
 //        release the outlock
 
-typedef enum {
-    LOGGER_NEXT_LSN = 0,
-    LOGGER_NUM_WRITES,
-    LOGGER_BYTES_WRITTEN,
-    LOGGER_UNCOMPRESSED_BYTES_WRITTEN,
-    LOGGER_TOKUTIME_WRITES,
-    LOGGER_WAIT_BUF_LONG,
-    LOGGER_STATUS_NUM_ROWS
-} logger_status_entry;
-
-typedef struct {
-    bool initialized;
-    TOKU_ENGINE_STATUS_ROW_S status[LOGGER_STATUS_NUM_ROWS];
-} LOGGER_STATUS_S, *LOGGER_STATUS;
-
 void toku_logger_get_status(TOKULOGGER logger, LOGGER_STATUS s);
 
 int toku_get_version_of_logs_on_disk(const char *log_dir, bool *found_any_logs, uint32_t *version_found);

--- a/ft/tests/cachetable-cleaner-thread-attrs-accumulate.cc
+++ b/ft/tests/cachetable-cleaner-thread-attrs-accumulate.cc
@@ -97,7 +97,7 @@ PATENT RIGHTS GRANT:
 toku_mutex_t attr_mutex;
 
 // used to access engine status variables 
-#define STATUS_VALUE(x) ct_status.status[x].value.num
+#define STATUS_VALUE(x) ct_test_status.status[CACHETABLE_STATUS_S::x].value.num
 
 const PAIR_ATTR attrs[] = {
     { .size = 20, .nonleaf_size = 13, .leaf_size = 900, .rollback_size = 123, .cache_pressure_size = 403, .is_valid = true },
@@ -150,8 +150,8 @@ run_test (void) {
     CACHEFILE f1;
     r = toku_cachetable_openf(&f1, ct, fname1, O_RDWR|O_CREAT, S_IRWXU|S_IRWXG|S_IRWXO); assert(r == 0);
 
-    CACHETABLE_STATUS_S ct_status;
-    toku_cachetable_get_status(ct, &ct_status);
+    CACHETABLE_STATUS_S ct_test_status;
+    toku_cachetable_get_status(ct, &ct_test_status);
     assert(STATUS_VALUE(CT_SIZE_NONLEAF) == 0);
     assert(STATUS_VALUE(CT_SIZE_LEAF) == 0);
     assert(STATUS_VALUE(CT_SIZE_ROLLBACK) == 0);
@@ -183,7 +183,7 @@ run_test (void) {
         expect.cache_pressure_size += attrs[i].cache_pressure_size;
     }
 
-    toku_cachetable_get_status(ct, &ct_status);
+    toku_cachetable_get_status(ct, &ct_test_status);
     assert(STATUS_VALUE(CT_SIZE_NONLEAF      ) == (uint64_t) expect.nonleaf_size);
     assert(STATUS_VALUE(CT_SIZE_LEAF         ) == (uint64_t) expect.leaf_size);
     assert(STATUS_VALUE(CT_SIZE_ROLLBACK     ) == (uint64_t) expect.rollback_size);
@@ -203,7 +203,7 @@ run_test (void) {
 
     usleep(2*1024*1024);
 
-    toku_cachetable_get_status(ct, &ct_status);
+    toku_cachetable_get_status(ct, &ct_test_status);
     assert(STATUS_VALUE(CT_SIZE_NONLEAF      ) == (uint64_t) expect.nonleaf_size);
     assert(STATUS_VALUE(CT_SIZE_LEAF         ) == (uint64_t) expect.leaf_size);
     assert(STATUS_VALUE(CT_SIZE_ROLLBACK     ) == (uint64_t) expect.rollback_size);

--- a/ft/tests/cachetable-simple-close.cc
+++ b/ft/tests/cachetable-simple-close.cc
@@ -193,13 +193,13 @@ simple_test(bool unlink_on_close) {
         assert(free_called);
         assert(!keep_me);
         // pair should NOT still be accounted for
-        assert(stats.status[CT_SIZE_CURRENT].value.num == 0);
+        assert(stats.status[CACHETABLE_STATUS_S::CT_SIZE_CURRENT].value.num == 0);
     }
     else {
         assert(keep_me);
         assert(!free_called);
         // pair should still be accounted for
-        assert(stats.status[CT_SIZE_CURRENT].value.num == 8);
+        assert(stats.status[CACHETABLE_STATUS_S::CT_SIZE_CURRENT].value.num == 8);
     }
     toku_cachetable_close(&ct);
     if (!unlink_on_close) {

--- a/ft/txn/txn.h
+++ b/ft/txn/txn.h
@@ -96,6 +96,7 @@ PATENT RIGHTS GRANT:
 
 #include "ft/txn/txn_state.h"
 #include "ft/serialize/block_table.h"
+#include "ft/ft-status.h"
 #include "util/omt.h"
 
 typedef uint64_t TXNID;
@@ -320,19 +321,6 @@ struct XIDS_S *toku_txn_get_xids(struct tokutxn *txn);
 // Force fsync on commit
 void toku_txn_force_fsync_on_commit(struct tokutxn *txn);
 
-typedef enum {
-    TXN_BEGIN,             // total number of transactions begun (does not include recovered txns)
-    TXN_READ_BEGIN,        // total number of read only transactions begun (does not include recovered txns)
-    TXN_COMMIT,            // successful commits
-    TXN_ABORT,
-    TXN_STATUS_NUM_ROWS
-} txn_status_entry;
-
-typedef struct {
-    bool initialized;
-    TOKU_ENGINE_STATUS_ROW_S status[TXN_STATUS_NUM_ROWS];
-} TXN_STATUS_S, *TXN_STATUS;
-
 void toku_txn_get_status(TXN_STATUS s);
 
 bool toku_is_txn_in_live_root_txn_list(const xid_omt_t &live_root_txn_list, TXNID xid);
@@ -376,10 +364,6 @@ time_t toku_txn_get_start_time(struct tokutxn *txn);
 //  - id > context->snapshot_txnid64 OR id is in context's live root transaction list
 //
 int toku_txn_reads_txnid(TXNID txnid, struct tokutxn *txn, bool is_provisional UU());
-
-void txn_status_init(void);
-
-void txn_status_destroy(void);
 
 // For serialize / deserialize
 

--- a/ft/ule.h
+++ b/ft/ule.h
@@ -101,9 +101,6 @@ PATENT RIGHTS GRANT:
 #include "txn/txn_manager.h"
 #include <util/mempool.h>
 
-void toku_ule_status_init(void);
-void toku_ule_status_destroy(void);
-
 // opaque handles used by outside world (i.e. indexer)
 typedef struct ule *ULEHANDLE;	
 typedef struct uxr *UXRHANDLE;

--- a/locktree/locktree.h
+++ b/locktree/locktree.h
@@ -104,33 +104,6 @@ PATENT RIGHTS GRANT:
 #include "wfg.h"
 #include "range_buffer.h"
 
-enum {
-    LTM_SIZE_CURRENT = 0,
-    LTM_SIZE_LIMIT,
-    LTM_ESCALATION_COUNT,
-    LTM_ESCALATION_TIME,
-    LTM_ESCALATION_LATEST_RESULT,
-    LTM_NUM_LOCKTREES,
-    LTM_LOCK_REQUESTS_PENDING,
-    LTM_STO_NUM_ELIGIBLE,
-    LTM_STO_END_EARLY_COUNT,
-    LTM_STO_END_EARLY_TIME,
-    LTM_WAIT_COUNT,
-    LTM_WAIT_TIME,
-    LTM_LONG_WAIT_COUNT,
-    LTM_LONG_WAIT_TIME,
-    LTM_TIMEOUT_COUNT,
-    LTM_WAIT_ESCALATION_COUNT,
-    LTM_WAIT_ESCALATION_TIME,
-    LTM_LONG_WAIT_ESCALATION_COUNT,
-    LTM_LONG_WAIT_ESCALATION_TIME,
-    LTM_STATUS_NUM_ROWS // must be last
-};
-
-typedef struct {
-    bool initialized;
-    TOKU_ENGINE_STATUS_ROW_S status[LTM_STATUS_NUM_ROWS];
-} LTM_STATUS_S, *LTM_STATUS;
 
 namespace toku {
 
@@ -254,8 +227,6 @@ namespace toku {
         lt_escalate_cb m_lt_escalate_callback;
         void *m_lt_escalate_callback_extra;
 
-        LTM_STATUS_S status;
-
         omt<locktree *> m_locktree_map;
 
         // the manager's mutex protects the locktree map
@@ -264,8 +235,6 @@ namespace toku {
         void mutex_lock(void);
 
         void mutex_unlock(void);
-
-        void status_init(void);
 
         // Manage the set of open locktrees
         locktree *locktree_map_find(const DICTIONARY_ID &dict_id);

--- a/locktree/manager.cc
+++ b/locktree/manager.cc
@@ -113,7 +113,6 @@ void locktree_manager::create(lt_create_cb create_cb, lt_destroy_cb destroy_cb, 
     ZERO_STRUCT(m_mutex);
     toku_mutex_init(&m_mutex, nullptr);
 
-    ZERO_STRUCT(status);
     ZERO_STRUCT(m_lt_counters);
 
     escalator_init();
@@ -486,52 +485,17 @@ void locktree_manager::locktree_escalator::run(locktree_manager *mgr, void (*esc
     mgr->add_escalator_wait_time(t1 - t0);
 }
 
-#define STATUS_INIT(k,c,t,l,inc) TOKUFT_STATUS_INIT(status, k, c, t, "locktree: " l, inc)
-
-void locktree_manager::status_init(void) {
-    STATUS_INIT(LTM_SIZE_CURRENT,             LOCKTREE_MEMORY_SIZE, UINT64,   "memory size", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(LTM_SIZE_LIMIT,               LOCKTREE_MEMORY_SIZE_LIMIT, UINT64,   "memory size limit", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(LTM_ESCALATION_COUNT,         LOCKTREE_ESCALATION_NUM, UINT64, "number of times lock escalation ran", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(LTM_ESCALATION_TIME,          LOCKTREE_ESCALATION_SECONDS, TOKUTIME, "time spent running escalation (seconds)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(LTM_ESCALATION_LATEST_RESULT, LOCKTREE_LATEST_POST_ESCALATION_MEMORY_SIZE, UINT64,   "latest post-escalation memory size", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(LTM_NUM_LOCKTREES,            LOCKTREE_OPEN_CURRENT, UINT64,   "number of locktrees open now", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(LTM_LOCK_REQUESTS_PENDING,    LOCKTREE_PENDING_LOCK_REQUESTS, UINT64,   "number of pending lock requests", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(LTM_STO_NUM_ELIGIBLE,         LOCKTREE_STO_ELIGIBLE_NUM, UINT64,   "number of locktrees eligible for the STO", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(LTM_STO_END_EARLY_COUNT,      LOCKTREE_STO_ENDED_NUM, UINT64,   "number of times a locktree ended the STO early", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(LTM_STO_END_EARLY_TIME,       LOCKTREE_STO_ENDED_SECONDS, TOKUTIME, "time spent ending the STO early (seconds)", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-
-    STATUS_INIT(LTM_WAIT_COUNT,               LOCKTREE_WAIT_COUNT, UINT64, "number of wait locks", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(LTM_WAIT_TIME,                LOCKTREE_WAIT_TIME, UINT64, "time waiting for locks", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(LTM_LONG_WAIT_COUNT,          LOCKTREE_LONG_WAIT_COUNT, UINT64, "number of long wait locks", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(LTM_LONG_WAIT_TIME,           LOCKTREE_LONG_WAIT_TIME, UINT64, "long time waiting for locks", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(LTM_TIMEOUT_COUNT,            LOCKTREE_TIMEOUT_COUNT, UINT64, "number of lock timeouts", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-
-    STATUS_INIT(LTM_WAIT_ESCALATION_COUNT,    LOCKTREE_WAIT_ESCALATION_COUNT, UINT64, "number of waits on lock escalation", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(LTM_WAIT_ESCALATION_TIME,     LOCKTREE_WAIT_ESCALATION_TIME, UINT64, "time waiting on lock escalation", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(LTM_LONG_WAIT_ESCALATION_COUNT,    LOCKTREE_LONG_WAIT_ESCALATION_COUNT, UINT64, "number of long waits on lock escalation", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-    STATUS_INIT(LTM_LONG_WAIT_ESCALATION_TIME,     LOCKTREE_LONG_WAIT_ESCALATION_TIME, UINT64, "long time waiting on lock escalation", TOKU_ENGINE_STATUS|TOKU_GLOBAL_STATUS);
-
-    status.initialized = true;
-}
-
-#undef STATUS_INIT
-
-#define STATUS_VALUE(x) status.status[x].value.num
-
 void locktree_manager::get_status(LTM_STATUS statp) {
-    if (!status.initialized) {
-        status_init();
-    }
-
-    STATUS_VALUE(LTM_SIZE_CURRENT) = m_current_lock_memory;
-    STATUS_VALUE(LTM_SIZE_LIMIT) = m_max_lock_memory;
-    STATUS_VALUE(LTM_ESCALATION_COUNT) = m_escalation_count;
-    STATUS_VALUE(LTM_ESCALATION_TIME) = m_escalation_time;
-    STATUS_VALUE(LTM_ESCALATION_LATEST_RESULT) = m_escalation_latest_result;
-    STATUS_VALUE(LTM_WAIT_ESCALATION_COUNT) = m_wait_escalation_count;
-    STATUS_VALUE(LTM_WAIT_ESCALATION_TIME) = m_wait_escalation_time;
-    STATUS_VALUE(LTM_LONG_WAIT_ESCALATION_COUNT) = m_long_wait_escalation_count;
-    STATUS_VALUE(LTM_LONG_WAIT_ESCALATION_TIME) = m_long_wait_escalation_time;    
+    ltm_status.init();
+    LTM_STATUS_VAL(LTM_SIZE_CURRENT) = m_current_lock_memory;
+    LTM_STATUS_VAL(LTM_SIZE_LIMIT) = m_max_lock_memory;
+    LTM_STATUS_VAL(LTM_ESCALATION_COUNT) = m_escalation_count;
+    LTM_STATUS_VAL(LTM_ESCALATION_TIME) = m_escalation_time;
+    LTM_STATUS_VAL(LTM_ESCALATION_LATEST_RESULT) = m_escalation_latest_result;
+    LTM_STATUS_VAL(LTM_WAIT_ESCALATION_COUNT) = m_wait_escalation_count;
+    LTM_STATUS_VAL(LTM_WAIT_ESCALATION_TIME) = m_wait_escalation_time;
+    LTM_STATUS_VAL(LTM_LONG_WAIT_ESCALATION_COUNT) = m_long_wait_escalation_count;
+    LTM_STATUS_VAL(LTM_LONG_WAIT_ESCALATION_TIME) = m_long_wait_escalation_time;    
 
     uint64_t lock_requests_pending = 0;
     uint64_t sto_num_eligible = 0;
@@ -559,18 +523,17 @@ void locktree_manager::get_status(LTM_STATUS statp) {
         mutex_unlock();
     }
 
-    STATUS_VALUE(LTM_NUM_LOCKTREES) = num_locktrees;
-    STATUS_VALUE(LTM_LOCK_REQUESTS_PENDING) = lock_requests_pending;
-    STATUS_VALUE(LTM_STO_NUM_ELIGIBLE) = sto_num_eligible;
-    STATUS_VALUE(LTM_STO_END_EARLY_COUNT) = sto_end_early_count;
-    STATUS_VALUE(LTM_STO_END_EARLY_TIME) = sto_end_early_time;
-    STATUS_VALUE(LTM_WAIT_COUNT) = lt_counters.wait_count;
-    STATUS_VALUE(LTM_WAIT_TIME) = lt_counters.wait_time;
-    STATUS_VALUE(LTM_LONG_WAIT_COUNT) = lt_counters.long_wait_count;
-    STATUS_VALUE(LTM_LONG_WAIT_TIME) = lt_counters.long_wait_time;
-    STATUS_VALUE(LTM_TIMEOUT_COUNT) = lt_counters.timeout_count;
-    *statp = status;
+    LTM_STATUS_VAL(LTM_NUM_LOCKTREES) = num_locktrees;
+    LTM_STATUS_VAL(LTM_LOCK_REQUESTS_PENDING) = lock_requests_pending;
+    LTM_STATUS_VAL(LTM_STO_NUM_ELIGIBLE) = sto_num_eligible;
+    LTM_STATUS_VAL(LTM_STO_END_EARLY_COUNT) = sto_end_early_count;
+    LTM_STATUS_VAL(LTM_STO_END_EARLY_TIME) = sto_end_early_time;
+    LTM_STATUS_VAL(LTM_WAIT_COUNT) = lt_counters.wait_count;
+    LTM_STATUS_VAL(LTM_WAIT_TIME) = lt_counters.wait_time;
+    LTM_STATUS_VAL(LTM_LONG_WAIT_COUNT) = lt_counters.long_wait_count;
+    LTM_STATUS_VAL(LTM_LONG_WAIT_TIME) = lt_counters.long_wait_time;
+    LTM_STATUS_VAL(LTM_TIMEOUT_COUNT) = lt_counters.timeout_count;
+    *statp = ltm_status;
 }
-#undef STATUS_VALUE
 
 } /* namespace toku */

--- a/locktree/tests/locktree_escalation_1big7lt_1small.cc
+++ b/locktree/tests/locktree_escalation_1big7lt_1small.cc
@@ -196,13 +196,13 @@ static void e_callback(TXNID txnid, const locktree *lt, const range_buffer &buff
 }
 
 static uint64_t get_escalation_count(locktree_manager &mgr) {
-    LTM_STATUS_S ltm_status;
-    mgr.get_status(&ltm_status);
+    LTM_STATUS_S ltm_status_test;
+    mgr.get_status(&ltm_status_test);
 
     TOKU_ENGINE_STATUS_ROW key_status = NULL;
     // lookup keyname in status
     for (int i = 0; ; i++) {
-        TOKU_ENGINE_STATUS_ROW status = &ltm_status.status[i];
+        TOKU_ENGINE_STATUS_ROW status = &ltm_status_test.status[i];
         if (status->keyname == NULL)
             break;
         if (strcmp(status->keyname, "LTM_ESCALATION_COUNT") == 0) {

--- a/locktree/tests/locktree_escalation_2big_1lt.cc
+++ b/locktree/tests/locktree_escalation_2big_1lt.cc
@@ -159,13 +159,13 @@ static void e_callback(TXNID txnid, const locktree *lt, const range_buffer &buff
 }
 
 static uint64_t get_escalation_count(locktree_manager &mgr) {
-    LTM_STATUS_S ltm_status;
-    mgr.get_status(&ltm_status);
+    LTM_STATUS_S ltm_status_test;
+    mgr.get_status(&ltm_status_test);
 
     TOKU_ENGINE_STATUS_ROW key_status = NULL;
     // lookup keyname in status
     for (int i = 0; ; i++) {
-        TOKU_ENGINE_STATUS_ROW status = &ltm_status.status[i];
+        TOKU_ENGINE_STATUS_ROW status = &ltm_status_test.status[i];
         if (status->keyname == NULL)
             break;
         if (strcmp(status->keyname, "LTM_ESCALATION_COUNT") == 0) {

--- a/locktree/tests/locktree_escalation_2big_2lt.cc
+++ b/locktree/tests/locktree_escalation_2big_2lt.cc
@@ -159,13 +159,13 @@ static void e_callback(TXNID txnid, const locktree *lt, const range_buffer &buff
 }
 
 static uint64_t get_escalation_count(locktree_manager &mgr) {
-    LTM_STATUS_S ltm_status;
-    mgr.get_status(&ltm_status);
+    LTM_STATUS_S ltm_status_test;
+    mgr.get_status(&ltm_status_test);
 
     TOKU_ENGINE_STATUS_ROW key_status = NULL;
     // lookup keyname in status
     for (int i = 0; ; i++) {
-        TOKU_ENGINE_STATUS_ROW status = &ltm_status.status[i];
+        TOKU_ENGINE_STATUS_ROW status = &ltm_status_test.status[i];
         if (status->keyname == NULL)
             break;
         if (strcmp(status->keyname, "LTM_ESCALATION_COUNT") == 0) {

--- a/locktree/tests/locktree_escalation_impossible.cc
+++ b/locktree/tests/locktree_escalation_impossible.cc
@@ -124,13 +124,13 @@ static void e_callback(TXNID txnid, const locktree *lt, const range_buffer &buff
 }
 
 static uint64_t get_escalation_count(locktree_manager &mgr) {
-    LTM_STATUS_S ltm_status;
-    mgr.get_status(&ltm_status);
+    LTM_STATUS_S ltm_status_test;
+    mgr.get_status(&ltm_status_test);
 
     TOKU_ENGINE_STATUS_ROW key_status = NULL;
     // lookup keyname in status
     for (int i = 0; ; i++) {
-        TOKU_ENGINE_STATUS_ROW status = &ltm_status.status[i];
+        TOKU_ENGINE_STATUS_ROW status = &ltm_status_test.status[i];
         if (status->keyname == NULL)
             break;
         if (strcmp(status->keyname, "LTM_ESCALATION_COUNT") == 0) {

--- a/locktree/tests/locktree_escalation_stalls.cc
+++ b/locktree/tests/locktree_escalation_stalls.cc
@@ -184,13 +184,13 @@ static void e_callback(TXNID txnid, const locktree *lt, const range_buffer &buff
 }
 
 static uint64_t get_escalation_count(locktree_manager &mgr) {
-    LTM_STATUS_S ltm_status;
-    mgr.get_status(&ltm_status);
+    LTM_STATUS_S ltm_status_test;
+    mgr.get_status(&ltm_status_test);
 
     TOKU_ENGINE_STATUS_ROW key_status = NULL;
     // lookup keyname in status
     for (int i = 0; ; i++) {
-        TOKU_ENGINE_STATUS_ROW status = &ltm_status.status[i];
+        TOKU_ENGINE_STATUS_ROW status = &ltm_status_test.status[i];
         if (status->keyname == NULL)
             break;
         if (strcmp(status->keyname, "LTM_ESCALATION_COUNT") == 0) {

--- a/src/ydb.cc
+++ b/src/ydb.cc
@@ -1899,15 +1899,15 @@ env_get_engine_status_num_rows (DB_ENV * UU(env), uint64_t * num_rowsp) {
     num_rows += YDB_LAYER_STATUS_NUM_ROWS;
     num_rows += YDB_C_LAYER_STATUS_NUM_ROWS;
     num_rows += YDB_WRITE_LAYER_STATUS_NUM_ROWS;
-    num_rows += LE_STATUS_NUM_ROWS;
-    num_rows += CP_STATUS_NUM_ROWS;
-    num_rows += CT_STATUS_NUM_ROWS;
-    num_rows += LTM_STATUS_NUM_ROWS;
-    num_rows += FT_STATUS_NUM_ROWS;
-    num_rows += FT_FLUSHER_STATUS_NUM_ROWS;
-    num_rows += FT_HOT_STATUS_NUM_ROWS;
-    num_rows += TXN_STATUS_NUM_ROWS;
-    num_rows += LOGGER_STATUS_NUM_ROWS;
+    num_rows += LE_STATUS_S::LE_STATUS_NUM_ROWS;
+    num_rows += CHECKPOINT_STATUS_S::CP_STATUS_NUM_ROWS;
+    num_rows += CACHETABLE_STATUS_S::CT_STATUS_NUM_ROWS;
+    num_rows += LTM_STATUS_S::LTM_STATUS_NUM_ROWS;
+    num_rows += FT_STATUS_S::FT_STATUS_NUM_ROWS;
+    num_rows += FT_FLUSHER_STATUS_S::FT_FLUSHER_STATUS_NUM_ROWS;
+    num_rows += FT_HOT_STATUS_S::FT_HOT_STATUS_NUM_ROWS;
+    num_rows += TXN_STATUS_S::TXN_STATUS_NUM_ROWS;
+    num_rows += LOGGER_STATUS_S::LOGGER_STATUS_NUM_ROWS;
     num_rows += MEMORY_STATUS_NUM_ROWS;
     num_rows += FS_STATUS_NUM_ROWS;
     num_rows += INDEXER_STATUS_NUM_ROWS;
@@ -1982,7 +1982,7 @@ env_get_engine_status (DB_ENV * env, TOKU_ENGINE_STATUS_ROW engstat, uint64_t ma
         {
             LE_STATUS_S lestat;                    // Rice's vampire
             toku_le_get_status(&lestat);
-            for (int i = 0; i < LE_STATUS_NUM_ROWS && row < maxrows; i++) {
+            for (int i = 0; i < LE_STATUS_S::LE_STATUS_NUM_ROWS && row < maxrows; i++) {
                 if (lestat.status[i].include & include_flags) {
                     engstat[row++] = lestat.status[i];
                 }
@@ -1991,7 +1991,7 @@ env_get_engine_status (DB_ENV * env, TOKU_ENGINE_STATUS_ROW engstat, uint64_t ma
         {
             CHECKPOINT_STATUS_S cpstat;
             toku_checkpoint_get_status(env->i->cachetable, &cpstat);
-            for (int i = 0; i < CP_STATUS_NUM_ROWS && row < maxrows; i++) {
+            for (int i = 0; i < CHECKPOINT_STATUS_S::CP_STATUS_NUM_ROWS && row < maxrows; i++) {
                 if (cpstat.status[i].include & include_flags) {
                     engstat[row++] = cpstat.status[i];
                 }
@@ -2000,7 +2000,7 @@ env_get_engine_status (DB_ENV * env, TOKU_ENGINE_STATUS_ROW engstat, uint64_t ma
         {
             CACHETABLE_STATUS_S ctstat;
             toku_cachetable_get_status(env->i->cachetable, &ctstat);
-            for (int i = 0; i < CT_STATUS_NUM_ROWS && row < maxrows; i++) {
+            for (int i = 0; i < CACHETABLE_STATUS_S::CT_STATUS_NUM_ROWS && row < maxrows; i++) {
                 if (ctstat.status[i].include & include_flags) {
                     engstat[row++] = ctstat.status[i];
                 }
@@ -2009,7 +2009,7 @@ env_get_engine_status (DB_ENV * env, TOKU_ENGINE_STATUS_ROW engstat, uint64_t ma
         {
             LTM_STATUS_S ltmstat;
             env->i->ltm.get_status(&ltmstat);
-            for (int i = 0; i < LTM_STATUS_NUM_ROWS && row < maxrows; i++) {
+            for (int i = 0; i < LTM_STATUS_S::LTM_STATUS_NUM_ROWS && row < maxrows; i++) {
                 if (ltmstat.status[i].include & include_flags) {
                     engstat[row++] = ltmstat.status[i];
                 }
@@ -2018,7 +2018,7 @@ env_get_engine_status (DB_ENV * env, TOKU_ENGINE_STATUS_ROW engstat, uint64_t ma
         {
             FT_STATUS_S ftstat;
             toku_ft_get_status(&ftstat);
-            for (int i = 0; i < FT_STATUS_NUM_ROWS && row < maxrows; i++) {
+            for (int i = 0; i < FT_STATUS_S::FT_STATUS_NUM_ROWS && row < maxrows; i++) {
                 if (ftstat.status[i].include & include_flags) {
                     engstat[row++] = ftstat.status[i];
                 }
@@ -2027,7 +2027,7 @@ env_get_engine_status (DB_ENV * env, TOKU_ENGINE_STATUS_ROW engstat, uint64_t ma
         {
             FT_FLUSHER_STATUS_S flusherstat;
             toku_ft_flusher_get_status(&flusherstat);
-            for (int i = 0; i < FT_FLUSHER_STATUS_NUM_ROWS && row < maxrows; i++) {
+            for (int i = 0; i < FT_FLUSHER_STATUS_S::FT_FLUSHER_STATUS_NUM_ROWS && row < maxrows; i++) {
                 if (flusherstat.status[i].include & include_flags) {
                     engstat[row++] = flusherstat.status[i];
                 }
@@ -2036,7 +2036,7 @@ env_get_engine_status (DB_ENV * env, TOKU_ENGINE_STATUS_ROW engstat, uint64_t ma
         {
             FT_HOT_STATUS_S hotstat;
             toku_ft_hot_get_status(&hotstat);
-            for (int i = 0; i < FT_HOT_STATUS_NUM_ROWS && row < maxrows; i++) {
+            for (int i = 0; i < FT_HOT_STATUS_S::FT_HOT_STATUS_NUM_ROWS && row < maxrows; i++) {
                 if (hotstat.status[i].include & include_flags) {
                     engstat[row++] = hotstat.status[i];
                 }
@@ -2045,7 +2045,7 @@ env_get_engine_status (DB_ENV * env, TOKU_ENGINE_STATUS_ROW engstat, uint64_t ma
         {
             TXN_STATUS_S txnstat;
             toku_txn_get_status(&txnstat);
-            for (int i = 0; i < TXN_STATUS_NUM_ROWS && row < maxrows; i++) {
+            for (int i = 0; i < TXN_STATUS_S::TXN_STATUS_NUM_ROWS && row < maxrows; i++) {
                 if (txnstat.status[i].include & include_flags) {
                     engstat[row++] = txnstat.status[i];
                 }
@@ -2054,7 +2054,7 @@ env_get_engine_status (DB_ENV * env, TOKU_ENGINE_STATUS_ROW engstat, uint64_t ma
         {
             LOGGER_STATUS_S loggerstat;
             toku_logger_get_status(env->i->logger, &loggerstat);
-            for (int i = 0; i < LOGGER_STATUS_NUM_ROWS && row < maxrows; i++) {
+            for (int i = 0; i < LOGGER_STATUS_S::LOGGER_STATUS_NUM_ROWS && row < maxrows; i++) {
                 if (loggerstat.status[i].include & include_flags) {
                     engstat[row++] = loggerstat.status[i];
                 }


### PR DESCRIPTION
Created new source files ft/ft-status.h and .cc to sort of "C++" the
way ft status values are handled. The problem is that each sub-system
handled stats slightly differently and usually used some static structs
local to only one.cc file. This made updating related stats across
files difficult, needing to add functions to expose stats to other
areas. Also made looking up stats a pain, needing to know were they
lived. Now, all stat enums for ft live in a single header and all stat
declarations are in a single .cc file and it is easy to manipulate/add
stats from anywhere.