### PR TITLE
FT-666 : Add more checkpoint status variables

### DIFF
--- a/ft/ft-status.cc
+++ b/ft/ft-status.cc
@@ -141,6 +141,9 @@ void CHECKPOINT_STATUS_S::init(void) {
     CP_STATUS_INIT(CP_BEGIN_TIME,                           CHECKPOINT_BEGIN_TIME,          UINT64,     "checkpoint begin time");
     CP_STATUS_INIT(CP_LONG_BEGIN_COUNT,                     CHECKPOINT_LONG_BEGIN_COUNT,    UINT64,     "long checkpoint begin count");
     CP_STATUS_INIT(CP_LONG_BEGIN_TIME,                      CHECKPOINT_LONG_BEGIN_TIME,     UINT64,     "long checkpoint begin time");
+    CP_STATUS_INIT(CP_END_TIME,                             CHECKPOINT_END_TIME,            UINT64,     "checkpoint end time");
+    CP_STATUS_INIT(CP_LONG_END_COUNT,                       CHECKPOINT_LONG_END_COUNT,      UINT64,     "long checkpoint end count");
+    CP_STATUS_INIT(CP_LONG_END_TIME,                        CHECKPOINT_LONG_END_TIME,       UINT64,     "long checkpoint end time");
 
     m_initialized = true;
 #undef CP_STATUS_INIT

--- a/ft/ft-status.h
+++ b/ft/ft-status.h
@@ -164,6 +164,9 @@ public:
         CP_BEGIN_TIME,
         CP_LONG_BEGIN_TIME,
         CP_LONG_BEGIN_COUNT,
+        CP_END_TIME,
+        CP_LONG_END_TIME,
+        CP_LONG_END_COUNT,
         CP_STATUS_NUM_ROWS       // number of rows in this status array.  must be last.
     };
 


### PR DESCRIPTION
Add new checkpoint status variables:
CP_END_TIME // checkpoint end time, time spend in checkpoint end operation in seconds
CP_LONG_END_COUNT // long checkpoint end count, count of end_checkpoint operations that exceeded 1 minute
CP_LONG_END_TIME // long checkpoint end time, total time of long checkpoints in seconds