### PR TITLE
FT-682 : don't call malloc_usable_size() so much

### DIFF
--- a/ft/msg_buffer.cc
+++ b/ft/msg_buffer.cc
@@ -92,6 +92,7 @@ PATENT RIGHTS GRANT:
 void message_buffer::create() {
     _num_entries = 0;
     _memory = nullptr;
+    _memory_usable = 0;
     _memory_size = 0;
     _memory_used = 0;
 }
@@ -102,11 +103,13 @@ void message_buffer::clone(message_buffer *src) {
     _memory_size = src->_memory_size;
     XMALLOC_N(_memory_size, _memory);
     memcpy(_memory, src->_memory, _memory_size);
+    _memory_usable = toku_malloc_usable_size(_memory);
 }
 
 void message_buffer::destroy() {
     if (_memory != nullptr) {
         toku_free(_memory);
+        _memory_usable = 0;
     }
 }
 
@@ -202,6 +205,7 @@ MSN message_buffer::deserialize_from_rbuf_v13(struct rbuf *rb,
 void message_buffer::_resize(size_t new_size) {
     XREALLOC_N(new_size, _memory);
     _memory_size = new_size;
+    _memory_usable = toku_malloc_usable_size(_memory);
 }
 
 static int next_power_of_two (int n) {
@@ -289,7 +293,17 @@ size_t message_buffer::memory_size_in_use() const {
 }
 
 size_t message_buffer::memory_footprint() const {
-    return sizeof(*this) + toku_memory_footprint(_memory, _memory_used);
+#ifdef TOKU_DEBUG_PARANOID
+    // Enable this code if you want to verify that the new way of computing
+    // the memory footprint is the same as the old.
+    // It slows the code down by perhaps 10%.
+    assert(_memory_usable == toku_malloc_usable_size(_memory));
+    size_t fp = toku_memory_footprint(_memory, _memory_used);
+    size_t fpg = toku_memory_footprint_given_usable_size(_memory_used, _memory_usable);
+    if (fp != fpg) printf("ptr=%p mu=%ld fp=%ld fpg=%ld\n", _memory, _memory_usable, fp, fpg);
+    assert(fp  == fpg);
+#endif // TOKU_DEBUG_PARANOID
+    return sizeof(*this) + toku_memory_footprint_given_usable_size(_memory_used, _memory_usable);
 }
 
 bool message_buffer::equals(message_buffer *other) const {

--- a/ft/msg_buffer.h
+++ b/ft/msg_buffer.h
@@ -178,4 +178,5 @@ private:
     char *_memory;       // An array of bytes into which buffer entries are embedded.
     int   _memory_size;  // How big is _memory
     int   _memory_used;  // How many bytes are in use?
+    size_t _memory_usable; // a cached result of toku_malloc_usable_size(_memory).
 };

--- a/portability/memory.h
+++ b/portability/memory.h
@@ -223,4 +223,11 @@ typedef struct memory_status {
 
 void toku_memory_get_status(LOCAL_MEMORY_STATUS s);
 
+// Effect: Like toku_memory_footprint, except instead of passing p,
+//   we pass toku_malloc_usable_size(p).
+size_t toku_memory_footprint_given_usable_size(size_t touched, size_t usable);
+
+// Effect: Return an estimate how how much space an object is using, possibly by
+//   using toku_malloc_usable_size(p).
+//   If p is NULL then returns 0.
 size_t toku_memory_footprint(void * p, size_t touched);


### PR DESCRIPTION
From Bradley K. with some minor code format and logic touch-ups:
"In some situations, calls to malloc_usable_size() were taking significant CPU cycles.
(Vadim measured 8% on a workload with a fanout of 128.)
We can remember the usable size of the message buffers, saving those CPU cycles."

Took his original pull request, squashed into single commit, fixed very minor code formatting and return logic.

Jenkins: http://jenkins.percona.com/view/TokuDB/job/ft-index-param/27