### PR TITLE
Unlocked signal evictor

### DIFF
--- a/ft/cachetable/cachetable-internal.h
+++ b/ft/cachetable/cachetable-internal.h
@@ -525,6 +525,7 @@ public:
     void evict_pair(PAIR p, bool checkpoint_pending);
     void wait_for_cache_pressure_to_subside();
     void signal_eviction_thread();
+    void signal_eviction_thread_locked();
     bool should_client_thread_sleep();
     bool should_client_wake_eviction_thread();
     // function needed for testing

--- a/ft/tests/test.h
+++ b/ft/tests/test.h
@@ -352,7 +352,7 @@ public:
         ev->m_period_in_seconds = 0;
         // signal eviction thread so that it wakes up
         // and then sleeps indefinitely
-        ev->signal_eviction_thread();
+        ev->signal_eviction_thread_locked();
         toku_mutex_unlock(&ev->m_ev_thread_lock);
         // sleep for one second to ensure eviction thread picks up new period
         usleep(1*1024*1024);

--- a/src/tests/helgrind.suppressions
+++ b/src/tests/helgrind.suppressions
@@ -144,3 +144,15 @@
    fun:_ZN4toku8treenode22remove_root_of_subtreeEv
    ...
 }
+{
+    helgrind_bug_https://bugs.kde.org/show_bug.cgi?id=327548
+    Helgrind:Race
+    fun:my_memcmp
+    fun:pthread_mutex_destroy
+}
+{
+    helgrind_bug_2_helgrind_bug_https://bugs.kde.org/show_bug.cgi?id=327548
+    Helgrind:Race
+    ...
+    fun:pthread_mutex_destroy
+}


### PR DESCRIPTION
helgrind and drd complain when the evictor cond var is signaled with the associated mutex held.  this change grabs the evictor mutex when signaling the evictor.  an alternate design could suppress the error.  IMO, the code change is safer.