### PR TITLE
Iter txn race

### DIFF
--- a/ft/cachetable/cachetable-internal.h
+++ b/ft/cachetable/cachetable-internal.h
@@ -525,6 +525,7 @@ public:
     void evict_pair(PAIR p, bool checkpoint_pending);
     void wait_for_cache_pressure_to_subside();
     void signal_eviction_thread();
+    void signal_eviction_thread_locked();
     bool should_client_thread_sleep();
     bool should_client_wake_eviction_thread();
     // function needed for testing

--- a/ft/tests/test.h
+++ b/ft/tests/test.h
@@ -352,7 +352,7 @@ public:
         ev->m_period_in_seconds = 0;
         // signal eviction thread so that it wakes up
         // and then sleeps indefinitely
-        ev->signal_eviction_thread();
+        ev->signal_eviction_thread_locked();
         toku_mutex_unlock(&ev->m_ev_thread_lock);
         // sleep for one second to ensure eviction thread picks up new period
         usleep(1*1024*1024);

--- a/ft/txn/txn.cc
+++ b/ft/txn/txn.cc
@@ -232,7 +232,7 @@ toku_txn_begin_with_xid (
         // this call will set txn->xids
         txn_create_xids(txn, parent);
     }
-    *txnp = txn;
+    toku_drd_unsafe_set(txnp, txn);
 exit:
     return r;
 }

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -174,8 +174,8 @@ if(BUILD_TESTING OR BUILD_SRC_TESTS)
 
   declare_custom_tests(test_groupcommit_count.tdb)
   add_ydb_test(test_groupcommit_count.tdb -n 1)
-  add_ydb_helgrind_test(test_groupcommit_count.tdb -n 1)
-  add_ydb_drd_test(test_groupcommit_count.tdb -n 1)
+  add_ydb_helgrind_test(test_groupcommit_count.tdb -n 2)
+  add_ydb_drd_test(test_groupcommit_count.tdb -n 2)
 
   add_ydb_drd_test(test_4015.tdb)
 

--- a/src/tests/helgrind.suppressions
+++ b/src/tests/helgrind.suppressions
@@ -144,3 +144,15 @@
    fun:_ZN4toku8treenode22remove_root_of_subtreeEv
    ...
 }
+{
+    helgrind_bug_https://bugs.kde.org/show_bug.cgi?id=327548
+    Helgrind:Race
+    fun:my_memcmp
+    fun:pthread_mutex_destroy
+}
+{
+    helgrind_bug_2_helgrind_bug_https://bugs.kde.org/show_bug.cgi?id=327548
+    Helgrind:Race
+    ...
+    fun:pthread_mutex_destroy
+}

--- a/src/ydb.cc
+++ b/src/ydb.cc
@@ -2503,6 +2503,8 @@ static int iter_txns_callback(TOKUTXN txn, void *extra) {
         reinterpret_cast<iter_txns_callback_extra *>(extra);
     DB_TXN *dbtxn = toku_txn_get_container_db_txn(txn);
     invariant_notnull(dbtxn);
+    struct __toku_db_txn_internal *db_txn_internal = db_txn_struct_i(dbtxn);
+    TOKU_VALGRIND_HG_DISABLE_CHECKING(db_txn_internal, sizeof *db_txn_internal);
     if (db_txn_struct_i(dbtxn)->tokutxn == txn) { // make sure that the dbtxn is fully initialized
         toku_mutex_lock(&db_txn_struct_i(dbtxn)->txn_mutex);
         toku_pthread_rwlock_rdlock(&info->env->i->open_dbs_rwlock);
@@ -2513,6 +2515,7 @@ static int iter_txns_callback(TOKUTXN txn, void *extra) {
         toku_pthread_rwlock_rdunlock(&info->env->i->open_dbs_rwlock);
         toku_mutex_unlock(&db_txn_struct_i(dbtxn)->txn_mutex);
     }
+    TOKU_VALGRIND_HG_ENABLE_CHECKING(db_txn_internal, sizeof *db_txn_internal);
 
     return r;
 }


### PR DESCRIPTION
live txn iterator is allowed to read the state of txn that can be concurrently changed by the client thread that is using the txn.

2217: ==29744== Conflicting load by thread 36 at 0x1d69c8c0 size 8
2217: ==29744==    at 0x5082139: toku_txn_id64(__toku_db_txn*) (ydb_txn.cc:109)
2217: ==29744==    by 0x412202: iterate_txns(__toku_db_txn*, int (*)(__toku_db**, __toku_dbt*, __toku_dbt*, void*), void*, void*) (test_stress0.cc:146)
2217: ==29744==    by 0x50719E1: iter_txns_callback(tokutxn*, void*) (ydb.cc:2511)
2217: ==29744==    by 0x5133FC9: txn_manager_iter(txn_manager*, int (*)(tokutxn*, void*), void*, bool) (txn_manager.cc:916)
2217: ==29744==    by 0x5134072: toku_txn_manager_iter_over_live_root_txns(txn_manager*, int (*)(tokutxn*, void*), void*) (txn_manager.cc:954)
2217: ==29744==    by 0x5071A98: env_iterate_live_transactions(__toku_db_env*, int (*)(__toku_db_txn*, int (*)(__toku_db**, __toku_dbt*, __toku_dbt*, void*), void*, void*), void*) (ydb.cc:2530)
2217: ==29744==    by 0x412441: iterate_live_transactions_op(__toku_db_txn*, arg*, void*, void*) (test_stress0.cc:170)
2217: ==29744==    by 0x4062EF: worker(void*) (threaded_stress_test_helpers.h:590)
2217: ==29744==    by 0x4C311FB: vgDrd_thread_wrapper (drd_pthread_intercepts.c:367)
2217: ==29744==    by 0x583B181: start_thread (pthread_create.c:312)
2217: ==29744==    by 0x5B4B47C: clone (clone.S:111)
2217: ==29744== Address 0x1d69c8c0 is at offset 144 from 0x1d69c830. Allocation context:
2217: ==29744==    at 0x4C2DFDD: malloc (vg_replace_malloc.c:296)
2217: ==29744==    by 0x53FF33F: os_malloc(unsigned long) (os_malloc.cc:267)
2217: ==29744==    by 0x53FE560: toku_xmalloc(unsigned long) (memory.cc:387)
2217: ==29744==    by 0x53FEC2E: toku_xcalloc(unsigned long, unsigned long) (memory.cc:435)
2217: ==29744==    by 0x5083409: toku_txn_begin(__toku_db_env*, __toku_db_txn*, __toku_db_txn**, unsigned int) (ydb_txn.cc:586)
2217: ==29744==    by 0x40623A: worker(void*) (threaded_stress_test_helpers.h:588)
2217: ==29744==    by 0x4C311FB: vgDrd_thread_wrapper (drd_pthread_intercepts.c:367)
2217: ==29744==    by 0x583B181: start_thread (pthread_create.c:312)
2217: ==29744==    by 0x5B4B47C: clone (clone.S:111)
2217: ==29744== Other segment start (thread 35)
2217: ==29744==    at 0x4C34A53: pthread_mutex_unlock_intercept (drd_pthread_intercepts.c:692)
2217: ==29744==    by 0x4C34A53: pthread_mutex_unlock (drd_pthread_intercepts.c:700)
2217: ==29744==    by 0x5130EF3: toku_mutex_unlock(toku_mutex*) (toku_pthread.h:239)
2217: ==29744==    by 0x51342A0: txn_manager_unlock(txn_manager*) (txn_manager.cc:1030)
2217: ==29744==    by 0x51336AE: toku_txn_manager_start_txn(tokutxn*, txn_manager*, __TXN_SNAPSHOT_TYPE, bool) (txn_manager.cc:702)
2217: ==29744==    by 0x512D743: toku_txn_begin_with_xid(tokutxn*, tokutxn**, tokulogger*, txnid_pair_s, __TXN_SNAPSHOT_TYPE, __toku_db_txn*, bool, bool) (txn.cc:220)
2217: ==29744==    by 0x5083515: toku_txn_begin(__toku_db_env*, __toku_db_txn*, __toku_db_txn**, unsigned int) (ydb_txn.cc:631)
2217: ==29744==    by 0x40623A: worker(void*) (threaded_stress_test_helpers.h:588)
2217: ==29744==    by 0x4C311FB: vgDrd_thread_wrapper (drd_pthread_intercepts.c:367)
2217: ==29744==    by 0x583B181: start_thread (pthread_create.c:312)
2217: ==29744==    by 0x5B4B47C: clone (clone.S:111)
2217: ==29744== Other segment end (thread 35)
2217: ==29744==    at 0x4C33D63: pthread_mutex_lock_intercept (drd_pthread_intercepts.c:642)
2217: ==29744==    by 0x4C33D63: pthread_mutex_lock (drd_pthread_intercepts.c:647)
2217: ==29744==    by 0x50994EE: toku_mutex_lock(toku_mutex*) (toku_pthread.h:204)
2217: ==29744==    by 0x509AE7B: toku::locktree_manager::iterate_pending_lock_requests(int (*)(DICTIONARY_ID, unsigned long, __toku_dbt const*, __toku_dbt const*, unsigned long, unsigned long, void*), vo\
id*) (manager.cc:364)
2217: ==29744==    by 0x5071786: env_iterate_pending_lock_requests(__toku_db_env*, int (*)(__toku_db*, unsigned long, __toku_dbt const*, __toku_dbt const*, unsigned long, unsigned long, void*), void*) (y\
db.cc:2436)
2217: ==29744==    by 0x41219F: iterate_pending_lock_requests_op(__toku_db_txn*, arg*, void*, void*) (test_stress0.cc:138)
2217: ==29744==    by 0x4062EF: worker(void*) (threaded_stress_test_helpers.h:590)