### PR TITLE
FT-700 is broken.  Undo parts of it and try to explain why.

### DIFF
--- a/ft/txn/txn.cc
+++ b/ft/txn/txn.cc
@@ -248,11 +248,22 @@ static txn_child_manager tcm;
         .xa_xid = {0, 0, 0, ""},
         .progress_poll_fun = NULL,
         .progress_poll_fun_extra = NULL,
-        .txn_lock = TOKU_MUTEX_INITIALIZER,
+
+        // You cannot initialize txn_lock a TOKU_MUTEX_INITIALIZER, because we
+        // will initialize it in the code below, and it cannot already
+        // be initialized at that point.  Also, in general, you don't
+        // get to use PTHREAD_MUTEX_INITALIZER (which is what is inside
+        // TOKU_MUTEX_INITIALIZER) except in static variables, and this
+        // is initializing an auto variable.
+        // 
+        // Simply avoid initializing these fields, which avoids -Wmissing-field-initializer errors under gcc (since this initialization uses designated initializers.)
+
+        .txn_lock = ZERO_MUTEX_INITIALIZER,   // Not TOKU_MUTEX_INITIALIZER
+
         .open_fts = open_fts,
         .roll_info = roll_info,
-        .state_lock = TOKU_MUTEX_INITIALIZER,
-        .state_cond = TOKU_COND_INITIALIZER,
+        .state_lock = ZERO_MUTEX_INITIALIZER, // Not TOKU_MUTEX_INITIALIZER
+        .state_cond = ZERO_COND_INITIALIZER,  // Not TOKU_COND_INITIALIZER
         .state = TOKUTXN_LIVE,
         .num_pin = 0,
         .client_id = 0,

--- a/portability/toku_pthread.h
+++ b/portability/toku_pthread.h
@@ -72,15 +72,17 @@ typedef struct toku_mutex_aligned {
     toku_mutex_t aligned_mutex __attribute__((__aligned__(64)));
 } toku_mutex_aligned_t;
 
-// Different OSes implement mutexes as different amounts of nested structs.
-// C++ will fill out all missing values with zeroes if you provide at least one zero, but it needs the right amount of nesting.
-#if defined(__FreeBSD__)
-# define ZERO_MUTEX_INITIALIZER {0}
-#elif defined(__APPLE__)
-# define ZERO_MUTEX_INITIALIZER {{0}}
-#else // __linux__, at least
-# define ZERO_MUTEX_INITIALIZER {{{0}}}
-#endif
+// Initializing with {} will fill in a struct with all zeros.
+// But you may also need a pragma to suppress the warnings, as follows
+//
+//   #pragma GCC diagnostic push
+//   #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+//   toku_mutex_t foo = ZERO_MUTEX_INITIALIZER;
+//   #pragma GCC diagnostic pop
+//
+// In general it will be a lot of busy work to make this codebase compile cleanly with -Wmissing-field-initializers
+
+# define ZERO_MUTEX_INITIALIZER {}
 
 #if TOKU_PTHREAD_DEBUG
 # define TOKU_MUTEX_INITIALIZER { .pmutex = PTHREAD_MUTEX_INITIALIZER, .owner = 0, .locked = false, .valid = true }


### PR DESCRIPTION
The head on master is broken.

We cannot use TOKU_MUTEX_INITIALIZER to avoid -Wmissing-field-initializers warnings, since TOKU_MUTEX_INITIALIZER employs PTHREAD_MUTEX_INITIALIZER.  PTHREAD_MUTEX_INITIALIZER can be used only on static variables, not stack-allocated (auto) variables.   Also, we immediately call pthread_mutex_init() on the mutex, so that if the initializer did work, it would be still be erroneous code.

It's probably not going to be easy to make -Wmissing-field-initializers warnings work.  One can use a pragma to tell the compiler not to complain about this particular instance.  It's probably cleaner to rework the initialization of those transactions to not use XMEMDUP and all that other junk, but rather to create a constructor for the TOKUTXN that does the right thing.
